### PR TITLE
mark broken sondes

### DIFF
--- a/pydropsonde/helper/paths.py
+++ b/pydropsonde/helper/paths.py
@@ -4,6 +4,7 @@ from pathlib import Path as pp
 from typing import Dict
 import os.path
 import warnings
+import ast
 
 from pydropsonde.helper import rawreader as rr
 from pydropsonde.processor import Sonde
@@ -187,6 +188,14 @@ class Flight:
                 global_attrs = get_global_attrs_from_config(config)
 
                 Sondes[sonde_id].add_global_attrs(global_attrs)
+                broken_file = config.get("OPTIONAL", "broken_sonde_file", fallback=None)
+                if broken_file is not None:
+                    with open(broken_file, "r") as file:
+                        file_content = file.read()
+
+                data_dict = ast.literal_eval(file_content)
+                Sondes[sonde_id].add_broken(data_dict)
+
             except UnboundLocalError:
                 warnings.warn(f"No valid a-file for sonde {sonde_id}, {self.flight_id}")
                 pass

--- a/pydropsonde/pipeline.py
+++ b/pydropsonde/pipeline.py
@@ -553,6 +553,7 @@ pipeline = {
         "functions": [
             "check_aspen_version",
             "check_pydropsonde_version",
+            "check_broken",
             "add_history_to_ds",
             "concat_sondes",
             "get_l3_dir",


### PR DESCRIPTION
Some of the sondes (especially on HALO-20240829a and HALO-20240831a) where recognized as minisondes by the ASPEN processing. It is possible to still process them with a different config, but I am not 100% sure that this processing is the same (in the software it says it's the same except for variables that use sonde weight and volume). 
Anyway, I thought it might be usefull to give an option on how to include those sondes anyways, and give them an attribute in Level2, resp a global attribute in Level3 with a list of all the sondes that gave some ASPEN error. 