### PR TITLE
Empty afiles

### DIFF
--- a/pydropsonde/helper/__init__.py
+++ b/pydropsonde/helper/__init__.py
@@ -115,7 +115,7 @@ l3_coords = dict(
 path_to_flight_ids = "{platform}/Level_0"
 path_to_l0_files = "{platform}/Level_0/{flight_id}"
 
-l2_filename_template = "{platform}_{launch_time}_{flight_id}_{serial_id}_Level_2.nc"
+l2_filename_template = "{platform}_{flight_id}_{serial_id}_Level_2.nc"
 
 l3_filename = "Level_3.nc"
 

--- a/pydropsonde/helper/paths.py
+++ b/pydropsonde/helper/paths.py
@@ -161,44 +161,46 @@ class Flight:
             try:
                 launch_detect = rr.check_launch_detect_in_afile(a_file)
                 launch_time = rr.get_launch_time(a_file)
-                Sondes[sonde_id] = Sonde(sonde_id, launch_time=launch_time)
-                Sondes[sonde_id].add_launch_detect(launch_detect)
-                Sondes[sonde_id].add_flight_id(
-                    self.flight_id,
-                    config.get(
-                        "processor.Sonde.add_flight_id",
-                        "flight_template",
-                        fallback=None,
-                    ),
+            except UnboundLocalError:
+                warnings.warn(
+                    f"No valid a-file for sonde {sonde_id}, {self.flight_id} - there is now launch detect or time information"
                 )
-                Sondes[sonde_id].add_platform_id(self.platform_id)
-                Sondes[sonde_id].add_afile(a_file)
-                Sondes[sonde_id].add_level_dir(
-                    l0_dir=config.get(
-                        "processor.Sonde.add_level_dir", "l0_dir", fallback=None
-                    ),
-                    l1_dir=config.get(
-                        "processor.Sonde.add_level_dir", "l1_dir", fallback=None
-                    ),
-                    l2_dir=config.get(
-                        "processor.Sonde.add_level_dir", "l2_dir", fallback=None
-                    ),
-                )
+                launch_detect = "UGLY"
+                launch_time = "UNKNOWN"
+            Sondes[sonde_id] = Sonde(sonde_id, launch_time=launch_time)
+            Sondes[sonde_id].add_launch_detect(launch_detect)
+            Sondes[sonde_id].add_flight_id(
+                self.flight_id,
+                config.get(
+                    "processor.Sonde.add_flight_id",
+                    "flight_template",
+                    fallback=None,
+                ),
+            )
+            Sondes[sonde_id].add_platform_id(self.platform_id)
+            Sondes[sonde_id].add_afile(a_file)
+            Sondes[sonde_id].add_level_dir(
+                l0_dir=config.get(
+                    "processor.Sonde.add_level_dir", "l0_dir", fallback=None
+                ),
+                l1_dir=config.get(
+                    "processor.Sonde.add_level_dir", "l1_dir", fallback=None
+                ),
+                l2_dir=config.get(
+                    "processor.Sonde.add_level_dir", "l2_dir", fallback=None
+                ),
+            )
 
-                global_attrs = get_global_attrs_from_config(config)
+            global_attrs = get_global_attrs_from_config(config)
 
-                Sondes[sonde_id].add_global_attrs(global_attrs)
-                broken_file = config.get("OPTIONAL", "broken_sonde_file", fallback=None)
-                if broken_file is not None:
-                    with open(broken_file, "r") as file:
-                        file_content = file.read()
+            Sondes[sonde_id].add_global_attrs(global_attrs)
+            broken_file = config.get("OPTIONAL", "broken_sonde_file", fallback=None)
+            if broken_file is not None:
+                with open(broken_file, "r") as file:
+                    file_content = file.read()
 
                 data_dict = ast.literal_eval(file_content)
                 Sondes[sonde_id].add_broken(data_dict)
-
-            except UnboundLocalError:
-                warnings.warn(f"No valid a-file for sonde {sonde_id}, {self.flight_id}")
-                pass
 
         object.__setattr__(self, "Sondes", Sondes)
 

--- a/pydropsonde/pipeline.py
+++ b/pydropsonde/pipeline.py
@@ -536,6 +536,7 @@ pipeline = {
             "add_attributes_as_var",
             "make_attr_coordinates",
             "make_prep_interim",
+            "add_expected_coords",
             "save_interim_l3",
         ],
         "output": "sondes",

--- a/pydropsonde/processor.py
+++ b/pydropsonde/processor.py
@@ -1470,6 +1470,7 @@ class Sonde:
         new_coords = {
             coord: ("sonde_id", np.reshape(ds[coord].values, (1,)), ds[coord].attrs)
             for coord in hh.l3_coords
+            if coord in ds.variables
         }
         ds = ds.assign_coords(new_coords)
         object.__setattr__(self, "_prep_l3_ds", ds)
@@ -1505,6 +1506,23 @@ class Sonde:
             alt_dim=alt_dim,
         )
 
+        return self
+
+    def add_expected_coords(self):
+        ds = self._interim_l3_ds
+        missing_coords = set(hh.l3_coords.keys()) - set(ds.coords)
+        for coord in missing_coords:
+            ds = ds.assign_coords(
+                {
+                    coord: (
+                        ("sonde_id",),
+                        np.full(ds.sizes["sonde_id"], np.nan),
+                        hh.l3_coords[coord],
+                    )
+                }
+            )
+
+        object.__setattr__(self, "_interim_l3_ds", ds)
         return self
 
 

--- a/pydropsonde/processor.py
+++ b/pydropsonde/processor.py
@@ -171,24 +171,30 @@ class Sonde:
             path_to_postaspenfile = os.path.join(l1_dir, l1_name)
 
         if not os.path.exists(path_to_postaspenfile):
-            os.makedirs(l1_dir, exist_ok=True)
-            subprocess.run(
-                [
-                    "docker",
-                    "run",
-                    "--rm",
-                    "--mount",
-                    f"type=bind,source={l0_dir},target=/input",
-                    "--mount",
-                    f"type=bind,source={l1_dir},target=/output",
-                    "ghcr.io/atmdrops/aspenqc:4.0.2",
-                    "-i",
-                    f"/input/{dname}",
-                    "-n",
-                    f"/output/{l1_name}",
-                ],
-                check=True,
-            )
+            if os.path.getsize(os.path.join(l0_dir, dname)) > 0:
+                os.makedirs(l1_dir, exist_ok=True)
+
+                subprocess.run(
+                    [
+                        "docker",
+                        "run",
+                        "--rm",
+                        "--mount",
+                        f"type=bind,source={l0_dir},target=/input",
+                        "--mount",
+                        f"type=bind,source={l1_dir},target=/output",
+                        "ghcr.io/atmdrops/aspenqc:4.0.2",
+                        "-i",
+                        f"/input/{dname}",
+                        "-n",
+                        f"/output/{l1_name}",
+                    ],
+                    check=True,
+                )
+            else:
+                warnings.warn(
+                    f"L0 file for sonde {self.serial_id} on {self.flight_id} is empty. No processing done"
+                )
 
         object.__setattr__(self, "postaspenfile", path_to_postaspenfile)
         return self

--- a/pydropsonde/processor.py
+++ b/pydropsonde/processor.py
@@ -228,6 +228,13 @@ class Sonde:
                     )
             elif ds.attrs["SondeId"] == self.serial_id:
                 object.__setattr__(self, "aspen_ds", ds)
+            elif self.launch_detect == "UGLY":
+                warnings.warn(
+                    f"I found the `SondeId` global attribute ({ds.attrs['SondeId']}) to not match with this instance's `serial_id` attribute ({self.serial_id}). This could be due to no afile for this sonde. Serial id is updated."
+                )
+                object.__setattr__(self, "serial_id", ds.attrs["SondeId"])
+                object.__setattr__(self, "aspen_ds", ds)
+
             else:
                 raise ValueError(
                     f"I found the `SondeId` global attribute ({ds.attrs['SondeId']}) to not match with this instance's `serial_id` attribute ({self.serial_id}). Therefore, I am not storing the xarray dataset as an attribute."

--- a/pydropsonde/processor.py
+++ b/pydropsonde/processor.py
@@ -216,7 +216,7 @@ class Sonde:
                 return None
             except OSError:
                 warnings.warn(
-                    f"Empty l1 file for sonde {self.serial_id} on {self.launch_time}. This might be fixed using the ASPEN software manually. "
+                    f"Empty l1 file for sonde {self.serial_id} on {self.flight_id}. This might be fixed using the ASPEN software manually. "
                 )
                 return None
             if "SondeId" not in ds.attrs:
@@ -806,9 +806,14 @@ class Sonde:
                     break
 
             attr = l2_flight_attributes_map.get(attr, attr)
-
-            value = lines[line_id].split("= ")[1]
-            flight_attrs[attr] = float(value) if "AVAPS" not in attr else value
+            try:
+                value = lines[line_id].split("= ")[1]
+                flight_attrs[attr] = float(value) if "AVAPS" not in attr else value
+            except UnboundLocalError:
+                print(
+                    f"No flight attributes for sonde {self.serial_id} on {self.flight_id}"
+                )
+                break
 
         object.__setattr__(self, "flight_attrs", flight_attrs)
 
@@ -1016,18 +1021,12 @@ class Sonde:
                     platform=self.platform_id,
                     serial_id=self.serial_id,
                     flight_id=self.flight_id,
-                    launch_time=self.launch_time.astype(datetime).strftime(
-                        "%Y-%m-%d_%H-%M"
-                    ),
                 )
             else:
                 l2_filename = hh.l2_filename_template.format(
                     platform=self.platform_id,
                     serial_id=self.serial_id,
                     flight_id=self.flight_id,
-                    launch_time=self.launch_time.astype(datetime).strftime(
-                        "%Y-%m-%d_%H-%M"
-                    ),
                 )
 
         object.__setattr__(self, "l2_filename", l2_filename)

--- a/pydropsonde/processor.py
+++ b/pydropsonde/processor.py
@@ -1199,11 +1199,14 @@ class Sonde:
                 curr_alt = alt[i]
         _prep_l3_ds[alt_var] = alt
 
-        mask = ~np.isnan(alt)
+        if np.all(np.isnan(alt)):
+            print(f"No {alt_var} values. Sonde is discarded")
+            return None
+
         object.__setattr__(
             self,
             "_prep_l3_ds",
-            _prep_l3_ds.sel(time=mask),
+            _prep_l3_ds,
         )
         return self
 

--- a/tests/test_sonde.py
+++ b/tests/test_sonde.py
@@ -147,5 +147,6 @@ def test_sonde_add_aspen_ds_with_mismatched_sonde_id(
     sonde.add_flight_id(flight_id)
     sonde.add_level_dir()
     sonde.run_aspen(temp_postaspenfile)
+    sonde.add_launch_detect(True)
     with pytest.raises(ValueError):
         sonde.add_aspen_ds()


### PR DESCRIPTION
Allow the processing of sondes that have a broken or empty afile. 

This also removes sondes that don't have any information about altitude from the pipeline between level 2. 