### PR TITLE
Adjust flight id for segmentation

### DIFF
--- a/pydropsonde/processor.py
+++ b/pydropsonde/processor.py
@@ -1934,7 +1934,7 @@ class Gridded:
             for platform_id in platform_ids
             for flight_id in flight_ids
             for s in segmentation.get(platform_id, {})
-            .get(flight_id, {})
+            .get(f"{platform_id}-{flight_id}a", {})
             .get("segments", [])
             if "circle" in s["kinds"]
         ]


### PR DESCRIPTION
No segments were being read from ORCESTRA data because the flight ID from the l3_ds was 20240926 (for example), and the flight ID in the segmentation file was "HALO-20240926a". This is not a super general fix for all types of segmentation files, though, so maybe there should be an entry in the config file?