### PR TITLE
catch empty segments in create circles

### DIFF
--- a/pydropsonde/pipeline.py
+++ b/pydropsonde/pipeline.py
@@ -249,7 +249,7 @@ def create_and_populate_flight_object(
 
 def create_and_populate_circle_object(
     gridded: Gridded, config: configparser.ConfigParser
-) -> dict:
+) -> dict[Circle]:
     """
     Create circle objects for further analysis
     """

--- a/pydropsonde/pipeline.py
+++ b/pydropsonde/pipeline.py
@@ -249,18 +249,22 @@ def create_and_populate_flight_object(
 
 def create_and_populate_circle_object(
     gridded: Gridded, config: configparser.ConfigParser
-) -> dict[Circle]:
+    ) -> dict[Circle]:
     """
-    Create circle objects for further analysis
+    create circle objects for further analysis
     """
+
     circles = {}
 
     for segment in gridded.segments:
         try:
             circle_ds = gridded.l3_ds.where(
-                gridded.l3_ds.launch_time > np.datetime64(segment["start"]), drop=True
-            ).where(gridded.l3_ds.launch_time < np.datetime64(segment["end"]))
-
+                (gridded.l3_ds["launch_time"] > np.datetime64(segment["start"])) & (gridded.l3_ds["launch_time"] < np.datetime64(segment["end"])),
+                drop=True,
+            )
+        except ValueError:
+            print(f"No data for segment {segment["segment_id"]}")
+        else:
             circle = Circle(
                 circle_ds=circle_ds,
                 flight_id=segment["flight_id"],
@@ -268,14 +272,9 @@ def create_and_populate_circle_object(
                 segment_id=segment["segment_id"],
                 alt_dim=gridded.alt_dim,
             )
-
             circles[segment["segment_id"]] = circle
 
-        except ValueError:
-            print(f"No sondes in segment {segment}")
-
     return circles
-
 
 def iterate_Sonde_method_over_dict_of_Sondes_objects(
     obj: dict, functions: list, config: configparser.ConfigParser

--- a/pydropsonde/pipeline.py
+++ b/pydropsonde/pipeline.py
@@ -249,29 +249,30 @@ def create_and_populate_flight_object(
 
 def create_and_populate_circle_object(
     gridded: Gridded, config: configparser.ConfigParser
-) -> dict[Circle]:
+) -> dict:
     """
-    create circle objects for further analysis
+    Create circle objects for further analysis
     """
-
     circles = {}
 
     for segment in gridded.segments:
-        circle_ds = gridded.l3_ds.where(
-            gridded.l3_ds["launch_time"] > np.datetime64(segment["start"]),
-            drop=True,
-        ).where(
-            gridded.l3_ds["launch_time"] < np.datetime64(segment["end"]),
-            drop=True,
-        )
-        circle = Circle(
-            circle_ds=circle_ds,
-            flight_id=segment["flight_id"],
-            platform_id=segment["platform_id"],
-            segment_id=segment["segment_id"],
-            alt_dim=gridded.alt_dim,
-        )
-        circles[segment["segment_id"]] = circle
+        try:
+            circle_ds = gridded.l3_ds.where(
+                gridded.l3_ds.launch_time > np.datetime64(segment["start"]), drop=True
+            ).where(gridded.l3_ds.launch_time < np.datetime64(segment["end"]))
+
+            circle = Circle(
+                circle_ds=circle_ds,
+                flight_id=segment["flight_id"],
+                platform_id=segment["platform_id"],
+                segment_id=segment["segment_id"],
+                alt_dim=gridded.alt_dim,
+            )
+
+            circles[segment["segment_id"]] = circle
+
+        except ValueError:
+            print(f"No sondes in segment {segment}")
 
     return circles
 

--- a/pydropsonde/pipeline.py
+++ b/pydropsonde/pipeline.py
@@ -249,7 +249,7 @@ def create_and_populate_flight_object(
 
 def create_and_populate_circle_object(
     gridded: Gridded, config: configparser.ConfigParser
-    ) -> dict[Circle]:
+) -> dict[Circle]:
     """
     create circle objects for further analysis
     """
@@ -259,7 +259,8 @@ def create_and_populate_circle_object(
     for segment in gridded.segments:
         try:
             circle_ds = gridded.l3_ds.where(
-                (gridded.l3_ds["launch_time"] > np.datetime64(segment["start"])) & (gridded.l3_ds["launch_time"] < np.datetime64(segment["end"])),
+                (gridded.l3_ds["launch_time"] > np.datetime64(segment["start"]))
+                & (gridded.l3_ds["launch_time"] < np.datetime64(segment["end"])),
                 drop=True,
             )
         except ValueError:
@@ -275,6 +276,7 @@ def create_and_populate_circle_object(
             circles[segment["segment_id"]] = circle
 
     return circles
+
 
 def iterate_Sonde_method_over_dict_of_Sondes_objects(
     obj: dict, functions: list, config: configparser.ConfigParser


### PR DESCRIPTION
Makes an exception when no sondes are found in a segment, because otherwise the pipeline fails when there are no sondes in a segment. 