### PR TITLE
Update the documentation

### DIFF
--- a/docs/source/data/index.rst
+++ b/docs/source/data/index.rst
@@ -4,25 +4,31 @@ Data
 
 This section outlines procedures for how to go about doing the quality control, the processing and the generation of data products.
 
-Data Directory Structure
-------------------------
+Data Products
+-------------
 
-Usually dropsonde data has a ``platform`` from which it was meassured and a ``flight_id`` from the exact flight it was taken from. After the processing each flight will have data on different levels of processing. ``pydropsonde`` uses the following levels.
+``pydropsonde`` splits the processing into several steps resulting in four data products.
+Below, the processing and (intermediate) data products are described in short in tabular form with links to detailed subpages.
 
 .. list-table::
-   :widths: 50 50
+   :widths: 20 20 60
    :header-rows: 1
 
-   * - Level
+   * - Data Product
+     - Data Files
      - Description
-   * - Level_0
-     - raw files from the AVAPS software (A-files, D-files, ...). Some files contain auxiliary data for a measurement sequence (usually a flight) and others are per sonde.
-   * - Level_1
-     - ASPEN-processed netCDF files per sonde. First QC applied.
+   * - :doc:`Level_0 <level0>`
+     - One file per sonde
+     - Raw files from the AVAPS software (A-files, D-files, ...)
+   * - :doc:`Level_1 <level1>`
+     - One file per sonde
+     - ASPEN-processed netCDF files including a first QC
    * - :doc:`Level_2 <level2>`
-     - Sondes that passed additional QC tests. Still one file per sonde. All soundings with no usable data are excluded
+     - One file per sonde
+     - Sonde profiles that passed additional QC tests
    * - :doc:`Level_3 <level3>`
-     - One dataset (file) containing all Level_2 soundings gridded on a uniform, vertical grid, with some derived variables
+     - one single file
+     - One dataset (file) containing all Level_2 soundings gridded on a uniform vertical grid and including some derived variables
    * - Level_4
      - one single file
      - Circle products from all circles flown during a measurement sequence, e.g. divergence

--- a/docs/source/data/index.rst
+++ b/docs/source/data/index.rst
@@ -84,15 +84,20 @@ with the respective config file entry:
         path_to_flight_ids = ./
         path_to_l0_files = {flight_id}/Level_0
 
-.. toctree::
-    :caption: Level Description
 In the course of the processing further data products or levels will be added at the respective places.
 In the first case Level_1 files would be saved to a single folder at ``platform / Level_1 / {flight_id} / netCDF files``.
 In the second case many Level_1 folders would be created following the pattern ``{flight_id} / Level_1 / netCDF files``.
 
-    level2
-    level3
 Level_2 works similar to Level_1 concerning the data directory structure.
 Up to this processing level each sonde profile is saved in a separate file.
 Level_3 on the other side is different in the sense that all profile data is vertically interpolated (see details above) and saved to a single file in the top directory specified in the mandatory section of the config file.
 Level_4 is likewise a single file stored next to Level_3.
+
+
+.. toctree::
+    :hidden:
+
+    level0
+    level1
+    level2
+    level3

--- a/docs/source/data/index.rst
+++ b/docs/source/data/index.rst
@@ -1,5 +1,5 @@
 Data
-=====
+====
 
 
 This section outlines procedures for how to go about doing the quality control, the processing and the generation of data products.
@@ -24,14 +24,69 @@ Usually dropsonde data has a ``platform`` from which it was meassured and a ``fl
    * - :doc:`Level_3 <level3>`
      - One dataset (file) containing all Level_2 soundings gridded on a uniform, vertical grid, with some derived variables
    * - Level_4
-     - Circle products from all circles flown during flight or measurement campaign
+     - one single file
+     - Circle products from all circles flown during a measurement sequence, e.g. divergence
 
 
+.. _data_directory_structure:
 
-You can define your exact folder structure as shown in :doc:`example configs <../tutorial/configs>`
+Data Directory Structure
+------------------------
+
+Before processing you need to store your dropsonde profile data in a coherent way and communicate that to the processing software via the config file.
+Most commonly, a sonde profile is associated with a ``platform`` from which it was dropped and a ``flight_id`` from the respective measurement flight.
+The AVAPS software is a standard tool for conducting dropsonde measurements in atmospheric science and the ``pydropsonde`` package builds on the AVAPS generated raw files (Level_0) and the ASPEN software designed by NCAR for applying a first quality control and changing the file format (Level_1). The resultign Data Levels are described in detail below.
+
+We suggest you to use as a default directory structure which fits the default output of the AVAPS and ASPEN software.
+At the end of a research flight with dropsonde measurements the AVAPS software saves individual sonde profile data in single files and adds several metadata files related to the whole flight.
+A possible data directory structure would therefore be:
+
+.. code-block:: ini
+
+        platform
+            |__ Level_0
+                |__ flight_id1
+                    |__ raw files
+                |__ flight_id2
+                    |__ raw files
+
+This is the assumed default structure and translates into the following statement to be made in the config file:
+
+.. code-block:: ini
+
+        [OPTIONAL]
+        path_to_flight_ids = {platform}/Level_0
+        path_to_l0_files = {platform}/Level_0/{flight_id}
+
+However, you are free in defining your favourite data strucutre that fits your use case and you could likewise save the data in another structure, e.g.
+
+
+.. code-block:: ini
+
+        flight_id1
+            |__ Level_0
+                    |__ raw files
+        flight_id2
+            |__ Level_0
+                    |__ raw files
+
+with the respective config file entry:
+
+.. code-block:: ini
+
+        [OPTIONAL]
+        path_to_flight_ids = ./
+        path_to_l0_files = {flight_id}/Level_0
 
 .. toctree::
     :caption: Level Description
+In the course of the processing further data products or levels will be added at the respective places.
+In the first case Level_1 files would be saved to a single folder at ``platform / Level_1 / {flight_id} / netCDF files``.
+In the second case many Level_1 folders would be created following the pattern ``{flight_id} / Level_1 / netCDF files``.
 
     level2
     level3
+Level_2 works similar to Level_1 concerning the data directory structure.
+Up to this processing level each sonde profile is saved in a separate file.
+Level_3 on the other side is different in the sense that all profile data is vertically interpolated (see details above) and saved to a single file in the top directory specified in the mandatory section of the config file.
+Level_4 is likewise a single file stored next to Level_3.

--- a/docs/source/data/index.rst
+++ b/docs/source/data/index.rst
@@ -1,8 +1,10 @@
 Data
 ====
 
+This section provides details on the processing steps, the resulting data products (levels), and the included quality control.
+When applying ``pydropsonde`` it is important to understand not only the different Data Products, but also where single products are stored.
+The latter is described in the section Data Directory Structure.
 
-This section outlines procedures for how to go about doing the quality control, the processing and the generation of data products.
 
 Data Products
 -------------

--- a/docs/source/data/index.rst
+++ b/docs/source/data/index.rst
@@ -27,7 +27,7 @@ Below, the processing and (intermediate) data products are described in short in
      - ASPEN-processed netCDF files including a first QC
    * - :doc:`Level_2 <level2>`
      - One file per sonde
-     - Sonde profiles that passed additional QC tests
+     - Sonde profiles with additional QC flags
    * - :doc:`Level_3 <level3>`
      - one single file
      - One dataset (file) containing all Level_2 soundings gridded on a uniform vertical grid and including some derived variables
@@ -43,9 +43,9 @@ Data Directory Structure
 
 Before processing you need to store your dropsonde profile data in a coherent way and communicate that to the processing software via the config file.
 Most commonly, a sonde profile is associated with a ``platform`` from which it was dropped and a ``flight_id`` from the respective measurement flight.
-The AVAPS software is a standard tool for conducting dropsonde measurements in atmospheric science and the ``pydropsonde`` package builds on the AVAPS generated raw files (Level_0) and the ASPEN software designed by NCAR for applying a first quality control and changing the file format (Level_1). The resultign Data Levels are described in detail below.
+The AVAPS software is a standard tool for conducting dropsonde measurements in atmospheric science and the ``pydropsonde`` package builds on the AVAPS generated raw files (Level_0). Further, the ASPEN software designed by NCAR is used to apply a first quality control and change the file format (Level_1). The resultign Data Levels are described in detail below.
 
-We suggest you to use as a default directory structure which fits the default output of the AVAPS and ASPEN software.
+We suggest to use a default directory structure which fits the default output of the AVAPS and ASPEN software.
 At the end of a research flight with dropsonde measurements the AVAPS software saves individual sonde profile data in single files and adds several metadata files related to the whole flight.
 A possible data directory structure would therefore be:
 
@@ -66,7 +66,7 @@ This is the assumed default structure and translates into the following statemen
         path_to_flight_ids = {platform}/Level_0
         path_to_l0_files = {platform}/Level_0/{flight_id}
 
-However, you are free in defining your favourite data strucutre that fits your use case and you could likewise save the data in another structure, e.g.
+However, you are free to define your favourite data strucutre that fits your use case and you could likewise save the data in another structure, e.g.
 
 
 .. code-block:: ini
@@ -92,7 +92,7 @@ In the second case many Level_1 folders would be created following the pattern `
 
 Level_2 works similar to Level_1 concerning the data directory structure.
 Up to this processing level each sonde profile is saved in a separate file.
-Level_3 on the other side is different in the sense that all profile data is vertically interpolated (see details above) and saved to a single file in the top directory specified in the mandatory section of the config file.
+Level_3 is different in the sense that all profile data is vertically interpolated (see details above) and saved to a single file in the top directory specified in the mandatory section of the config file.
 Level_4 is likewise a single file stored next to Level_3.
 
 

--- a/docs/source/data/level0.rst
+++ b/docs/source/data/level0.rst
@@ -1,9 +1,9 @@
 Level 0
 =======
 
-Level_0 refers to the raw data files saved by the `AVAPS Dropsonde System <https://www.eol.ucar.edu/observing_facilities/avaps-dropsonde-system>`_ in it's default configuration.
+Level_0 refers to the raw data files saved by the `AVAPS Dropsonde System <https://www.eol.ucar.edu/observing_facilities/avaps-dropsonde-system>`_ in its default configuration.
 For each dropped sonde that system stores the data in different formats, partly with overlapping information.
-In addition to the singel profile files, the system saves metadata related to a measurement sequence, typically one flight, as defined by the start and closing of the AVAPS software.
+In addition to the single profile files, the system saves metadata related to a measurement sequence, typically one flight, as defined by the start and closing of the AVAPS software.
 
 An overview of typical files stored at Level_0 is shown in `George et al., 2021 <https://essd.copernicus.org/articles/13/5253/2021/essd-13-5253-2021.html>`_ and copied below:
 
@@ -33,3 +33,7 @@ An overview of typical files stored at Level_0 is shown in `George et al., 2021 
      - TXT file of GPS data: GPGGA (system fix data) and GPRMC (minimum specific GPS/Transit data)
    * - 3_SpecAnlyzr files
      - TXT file of logs of spectral analyzer
+
+``pydropsonde`` uses the `D files` with the actual sonde profile data in the further processing.
+Metadata information from the `A files`, e.g. a successful launch detect, is added within the processing.
+In principle, the processing can run without `A files`, but obviously does not have metadata in that case.

--- a/docs/source/data/level0.rst
+++ b/docs/source/data/level0.rst
@@ -1,0 +1,35 @@
+Level 0
+=======
+
+Level_0 refers to the raw data files saved by the `AVAPS Dropsonde System <https://www.eol.ucar.edu/observing_facilities/avaps-dropsonde-system>`_ in it's default configuration.
+For each dropped sonde that system stores the data in different formats, partly with overlapping information.
+In addition to the singel profile files, the system saves metadata related to a measurement sequence, typically one flight, as defined by the start and closing of the AVAPS software.
+
+An overview of typical files stored at Level_0 is shown in `George et al., 2021 <https://essd.copernicus.org/articles/13/5253/2021/essd-13-5253-2021.html>`_ and copied below:
+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - File Type
+     - Description
+   * - A files
+     - Sounding attribute file; includes channel configuration, COM port data, hardware configuration, launch obs data, sensor errors, aircraft data, software config and firmware information
+   * - B files
+     - File containing binary data; same as D files
+   * - C files
+     - Sounding data stored as comma-separated-value files
+   * - D files
+     - Raw sounding data recorded for timestamp at every 0.25 s
+   * - D_P files
+     - Only post-launch raw data; same as D files
+   * - R files
+     - Receiver port data: signal strength and receiver frequency
+   * - 0_SysLog files
+     - Comma-separated-value file of all AVAPS system logs
+   * - 1_Aircraft files
+     - TXT file of aircraft position data in the IWGADTS format (IWG1)
+   * - 2_GPSRef files
+     - TXT file of GPS data: GPGGA (system fix data) and GPRMC (minimum specific GPS/Transit data)
+   * - 3_SpecAnlyzr files
+     - TXT file of logs of spectral analyzer

--- a/docs/source/data/level1.rst
+++ b/docs/source/data/level1.rst
@@ -3,7 +3,7 @@ Level_1
 
 The Level_1 data is a direct output of the `Aspen <https://www.eol.ucar.edu/content/aspen>`_ software provided by NCAR.
 It is used for a basic quality control and ``pydropsonde`` assumes that Aspen is run in it's default configuration.
-For details on the basic quality control, please have a look at the `AspenDocs <https://ncar.github.io/aspendocs/index.html>`_.
+For details on the basic quality control steps as well as the standard netCDF output files, please have a look at the `AspenDocs <https://ncar.github.io/aspendocs/index.html>`_.
 
 There are two ways for processing sonde profiles from Level_0 to Level_1 via Aspen:
 
@@ -13,3 +13,8 @@ There are two ways for processing sonde profiles from Level_0 to Level_1 via Asp
 If you opt for processing with docker, you need to install `docker <https://www.docker.com/>`_ and start a docker daemon (dockerd) locally to be able to use the ASPEN docker image.
 The simplest way would be to install Docker Desktop (on MacOS also possible via ``brew install --cask docker``) and open the application before executing ``pydropsonde``.
 Further information can be found in the respective `Aspen docker image <https://github.com/atmdrops/aspenqc>`_ repository.
+
+.. note::
+   In case that sondes are recognized as "minisondes", processing via the Docker image or CLI will result in errors.
+   The Level_0 to Level_1 processing can still be done manually with (Batch)Aspen with the minisonde configuration file.
+   From Level_1 onwards those files are then included in the pipeline.

--- a/docs/source/data/level1.rst
+++ b/docs/source/data/level1.rst
@@ -1,10 +1,15 @@
 Level_1
 =======
 
-The Level_1 data is a direct output of the ASPEN software provided by NCAR.
+The Level_1 data is a direct output of the `Aspen <https://www.eol.ucar.edu/content/aspen>`_ software provided by NCAR.
+It is used for a basic quality control and ``pydropsonde`` assumes that Aspen is run in it's default configuration.
+For details on the basic quality control, please have a look at the `AspenDocs <https://ncar.github.io/aspendocs/index.html>`_.
 
-* link to ASPEN QC and describe main features
-* 2 ways of processing: GUI or setup via docker
-* ASPEN software version
-* output format
-* other options in ASPEN?
+There are two ways for processing sonde profiles from Level_0 to Level_1 via Aspen:
+
+#. by default, ``pydropsonde`` will use an `Aspen docker image <https://github.com/atmdrops/aspenqc>`_ named `ghcr.io/atmdrops/aspenqc` and hosted on GitHub for running Aspen independent of your local operating system. It uses the latest Aspen software version available as docker image (v4.0.2 available since Jun 7, 2024) if not specified differently. The Aspen QC is run in default configuration and saves the output data in netCDF format.
+#. Alternatively, you can process your raw files manually with Aspen. ``pydropsonde`` won't reprocess the files if they are saved within your :ref:`data_directory_structure`. Download your favourite version of Aspen from the `NCAR Software Center <https://www.eol.ucar.edu/software/aspen>`_ and either use the command line interface or the included GUI "BatchAspen" for processing individual or a group of files. For further processing with ``pydropsonde`` the output file format should be netCDF.
+
+If you opt for processing with docker, you need to install `docker <https://www.docker.com/>`_ and start a docker daemon (dockerd) locally to be able to use the ASPEN docker image.
+The simplest way would be to install Docker Desktop (on MacOS also possible via ``brew install --cask docker``) and open the application before executing ``pydropsonde``.
+Further information can be found in the respective `Aspen docker image <https://github.com/atmdrops/aspenqc>`_ repository.

--- a/docs/source/data/level1.rst
+++ b/docs/source/data/level1.rst
@@ -1,0 +1,10 @@
+Level_1
+=======
+
+The Level_1 data is a direct output of the ASPEN software provided by NCAR.
+
+* link to ASPEN QC and describe main features
+* 2 ways of processing: GUI or setup via docker
+* ASPEN software version
+* output format
+* other options in ASPEN?

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,22 +1,18 @@
+pydropsonde
+===========
 
+``pydropsonde`` is a python package for processing atmospheric profile measurements from dropsondes.
+It is based on the software part in `halodrops <https://github.com/Geet-George/halodrops>`_.
 
-pydropsonde Documentation
-=========================
-
-.. warning::
-
-   Currently under active development.
-
-This is a python package to process dropsonde data. It is based on the software part in `halodrops <https://github.com/Geet-George/halodrops>`_.
-
-For a quick start go to the :doc:`Tutorials <../tutorial/index>`. Under :doc:`Data <../data/index>`, the structure of the dropsonde data is described.
-
+Dropsondes are small measurement devices that when dropped from high altitudes will measure a vertical profile of temperature, pressure, relative humidity and winds in the atmosphere.
+The profile data needs to run through several quality control steps and can be further processed to userfriendly dataset potentially including derived data.
+Individual processing steps and the resulting data levels available from `pydropsonde` are described in increasing detail in the below subsections.
 
 .. toctree::
    :maxdepth: 1
-   :caption: overview
+   :caption: Table of Contents
 
-   CONTRIBUTING
-   data/index
    tutorial/index
+   data/index
    api
+   CONTRIBUTING

--- a/docs/source/tutorial/configs.rst
+++ b/docs/source/tutorial/configs.rst
@@ -1,8 +1,15 @@
 Config Files
 ============
 
+Each config file has a mandatory and an optional section. The below description shows exemplarily the general structure and main features.
+However, you can find an example for a valid config file ``dropsonde.cfg`` that works with the example data ``example_data/`` which is all stored within the `GitHub repository <https://github.com/atmdrops/pydropsonde>`_ that also hosts the pages of the documentation that you are currently reading.
 
-Each config file has a mandatory section that contains the data directory of the dropsonde data like
+
+.. _mandatory:
+
+MANDATORY
+---------
+The mandatory section contains the data directory of the dropsonde data like
 
 .. code-block:: ini
 
@@ -10,7 +17,23 @@ Each config file has a mandatory section that contains the data directory of the
         data_directory = ./example_data
 
 Technically, this is everything a valid config file needs. However, you can specify the place of your flight folders and of the actual dropsonde data in an optional section.
-For the example data this would be
+
+.. _optional:
+
+OPTIONAL
+--------
+
+The optional arguments comprise statements on the present data structure, global attributes and a very powerful mechanism to shape the processing in various data levels e.g. by adding certain quality control tests.
+
+Data structure
+**************
+
+A frequent usecase in this section is the definition of your folder structure if you have multiple sonde profiles from e.g.
+different platforms or single flights and possibly also already existing preprocessed data levels (see :ref:`data_directory_structure` for details).
+Based on the example data mentioned above, we could specify
+
+#. the path to the folders containing sonde profiles of a singel flight ``path_to_flight_ids``
+#. the path to the actual Level_0 files ``path_to_l0_files``
 
 .. code-block:: ini
 
@@ -18,7 +41,12 @@ For the example data this would be
         path_to_flight_ids = {platform}/Level_0
         path_to_l0_files = {platform}/Level_0/{flight_id}
 
-If there are any global attributes that should be added to any dataset that is saved, those can be added to the GLOBAL_ATTRS section. For example
+Global attributes
+*****************
+
+Another usecase are global attributes that shall be added to any dataset that is saved.
+You can specify any global attributes such as ``author`` or contact details ``author_email`` in a ``GLOBAL_ATTRS`` section.
+For example
 
 .. code-block:: ini
 
@@ -26,13 +54,24 @@ If there are any global attributes that should be added to any dataset that is s
         author = Geet George
         author_email = g.george@tudelft.nl
 
-would add the attributes ``author : Geet George`` and ``author_email : g.george@tudelft.nl``. The pydropsonde version used for processing will be added as a global attribute in any case.
+The pydropsonde version used for processing will be added as a global attribute in any case.
 
-Other optional function parameters can be specified with their function as a section. To specify the L2 and L3 filenames this could be
+Modifying the processing
+************************
+
+Any deviation from the default processing can be specified in the config file by stating the respective arguments to a function.
+For example, you can specify the quality control filter applied when processing data to Level_2.
+
+.. code-block:: ini
+
+        [processor.Sonde.filter_qc_fail]
+        filter_flags = profile_fullness,near_surface_coverage,alt_near_gpsalt
+
+Also, you can customize the Level_2 and Level_3 file names as shown below.
 
 .. code-block:: ini
 
         [processor.Sonde.get_l2_filename]
-        l2_filename_template = PERCUSION_{platform}_{launch_time}_{flight_id}_{serial_id}_Level_2.nc
+        l2_filename_template = campaign_name_{platform}_{launch_time}_{flight_id}_{serial_id}_Level_2.nc
         [processor.Gridded.get_l3_filename]
-        l3_filename_template = PERCUSION_{platform}_{flight_id}_Level_3.nc
+        l3_filename_template = campaign_name_{platform}_{flight_id}_Level_3.nc

--- a/docs/source/tutorial/configs.rst
+++ b/docs/source/tutorial/configs.rst
@@ -1,8 +1,9 @@
 Config Files
 ============
 
-Each config file has a mandatory and an optional section. The below description shows exemplarily the general structure and main features.
-However, you can find an example for a valid config file ``dropsonde.cfg`` that works with the example data ``example_data/`` which is all stored within the `GitHub repository <https://github.com/atmdrops/pydropsonde>`_ that also hosts the pages of the documentation that you are currently reading.
+A valid config file states at least the path to the dropsonde data in the mandatory section.
+The below description shows exemplarily the general structure and lists further optional statements.
+For illustration, you can find an example for a valid config file ``dropsonde.cfg`` that works with the example data ``example_data/`` in the `pydropsonde GitHub repository <https://github.com/atmdrops/pydropsonde>`_ that also hosts the pages of the documentation that you are currently reading.
 
 
 .. _mandatory:

--- a/docs/source/tutorial/index.rst
+++ b/docs/source/tutorial/index.rst
@@ -5,7 +5,7 @@ Getting Started
 
 This page explains how to install and run the ``pydropsonde`` python package.
 To run the package, a config file is mandatory. Basic instructions for setting up a config file and running pydropsonde with it are described below.
-The package includes functions to process the dropsonde data from raw files to datasets on uniform grids and including several derived meteorological variables.
+The package includes functions to process the dropsonde data from raw files to datasets on uniform grids and to derive further meteorological variables.
 
 
 .. toctree::

--- a/docs/source/tutorial/index.rst
+++ b/docs/source/tutorial/index.rst
@@ -3,20 +3,15 @@ Getting Started
 
 
 
-This page explains how to install and run the ``pydropsonde`` python package. The package includes functions to process the dropsonde data from raw files to datasets on uniform grids and including several derived meteorological variables.
+This page explains how to install and run the ``pydropsonde`` python package.
+To run the package, a config file is mandatory. Basic instructions for setting up a config file and running pydropsonde with it are described below.
+The package includes functions to process the dropsonde data from raw files to datasets on uniform grids and including several derived meteorological variables.
 
-To run ``pydropsonde`` on a set of dropsonde data, you first need to create a respective configuration file. An example and further infos are provided below. To run the ``pydropsonde`` pipeline, you need to provide the path to the config file:
-
-.. code-block:: bash
-
-        pydropsonde -c <config_file>
-
-
-The processing from Level_0 to Level_1 (using `aspen <https://www.eol.ucar.edu/content/aspen>`_) is included in ``pydropsonde``. It makes use of a docker image containing the ASPEN software. Before actually calling pydropsonde, you therefore need to install `docker <https://www.docker.com/>`_ and start a docker daemon (dockerd) locally to be able to use the ASPEN docker image.
-The simplest way would be to install Docker Desktop (on MacOS also possible via ``brew install --cask docker``) and open the application before executing pydropsonde. Further information can be found in the respective `aspenqc <https://github.com/atmdrops/aspenqc>`_ repository.
 
 .. toctree::
-    :caption: Contents:
+    :caption: Sections:
+    :maxdepth: 1
 
     installation
     configs
+    run

--- a/docs/source/tutorial/installation.rst
+++ b/docs/source/tutorial/installation.rst
@@ -1,24 +1,27 @@
 Installation
 ============
 
-For now, ``pydropsonde`` is not a ``pip`` or ``conda`` package.
-You can either clone the repository by
+Currently, there are two ways to install the package.
 
-.. code-block:: bash
+#. ``pydropsonde`` is available via `PyPI <https://pypi.org/project/pydropsonde/>`_ such that you can directly install the package with ``pip``
 
-        git clone git@github.com:atmdrops/pydropsonde.git
+   .. code-block:: bash
+
+       pip install pydropsonde
 
 
-and create a respective python environment with ``conda`` from the base folder directory:
+#. Alternatively, you can clone the repository by
 
-.. code-block:: bash
+   .. code-block:: bash
 
-    conda env create -f environment.yaml
+           git clone git@github.com:atmdrops/pydropsonde.git
 
-This will install ``pydropsonde`` in development mode.
 
-Alternatively, you can directly install the package with ``pip``
+   and create a respective python environment with ``conda`` from the base folder directory:
 
-.. code-block:: bash
+   .. code-block:: bash
 
-    pip install pydropsonde
+       conda env create -f environment.yaml
+
+   This will install ``pydropsonde`` in development mode.
+

--- a/docs/source/tutorial/installation.rst
+++ b/docs/source/tutorial/installation.rst
@@ -24,4 +24,3 @@ Currently, there are two ways to install the package.
        conda env create -f environment.yaml
 
    This will install ``pydropsonde`` in development mode.
-

--- a/docs/source/tutorial/run.rst
+++ b/docs/source/tutorial/run.rst
@@ -9,13 +9,7 @@ By default, ``pydropsonde`` would search for `dropsonde.cfg` in the current dire
 
         pydropsonde -c <path_to_config_file>
 
-Notes on processing to Level_1
-______________________________
-
-The processing from Level_0 to Level_1 (using `aspen <https://www.eol.ucar.edu/content/aspen>`_) is included in ``pydropsonde``.
-It makes use of a docker image containing the ASPEN software.
-Before actually calling pydropsonde, you therefore need to install `docker <https://www.docker.com/>`_ and start a docker daemon (dockerd) locally to be able to use the ASPEN docker image.
-The simplest way would be to install Docker Desktop (on MacOS also possible via ``brew install --cask docker``) and open the application before executing pydropsonde.
-Further information can be found in the respective `aspenqc <https://github.com/atmdrops/aspenqc>`_ repository.
-
-Alternatively, you can use the GUI provided by ASPEN to process Level_0 to Level_1. ``pydropsonde`` won't reprocess Level_1 if the respective files are already available.
+.. note::
+   The processing from Level_0 to Level_1 using `Aspen <https://www.eol.ucar.edu/content/aspen>`_ is included in ``pydropsonde``.
+   It makes use of a docker image containing the Aspen software.
+   If you are unfamiliar with `docker`, have a look at the :doc:`../data/level1` description to learn how to install `docker` and start a `docker daemon`.

--- a/docs/source/tutorial/run.rst
+++ b/docs/source/tutorial/run.rst
@@ -1,7 +1,7 @@
 Running pydropsonde
 ===================
 
-To run ``pydropsonde`` on a set of sonde profiles, you first need to create a respective configuration file (see :doc:`Config Files <configs>`).
+To run ``pydropsonde`` on a set of sonde profiles, you first need to create a configuration file (see :doc:`Config Files <configs>`).
 Further, you can provide the path to the config file through the ``-c`` option.
 By default, ``pydropsonde`` would search for `dropsonde.cfg` in the current directory.
 

--- a/docs/source/tutorial/run.rst
+++ b/docs/source/tutorial/run.rst
@@ -1,0 +1,21 @@
+Running pydropsonde
+===================
+
+To run ``pydropsonde`` on a set of sonde profiles, you first need to create a respective configuration file (see :doc:`Config Files <configs>`).
+Further, you can provide the path to the config file through the ``-c`` option.
+By default, ``pydropsonde`` would search for `dropsonde.cfg` in the current directory.
+
+.. code-block:: bash
+
+        pydropsonde -c <path_to_config_file>
+
+Notes on processing to Level_1
+______________________________
+
+The processing from Level_0 to Level_1 (using `aspen <https://www.eol.ucar.edu/content/aspen>`_) is included in ``pydropsonde``.
+It makes use of a docker image containing the ASPEN software.
+Before actually calling pydropsonde, you therefore need to install `docker <https://www.docker.com/>`_ and start a docker daemon (dockerd) locally to be able to use the ASPEN docker image.
+The simplest way would be to install Docker Desktop (on MacOS also possible via ``brew install --cask docker``) and open the application before executing pydropsonde.
+Further information can be found in the respective `aspenqc <https://github.com/atmdrops/aspenqc>`_ repository.
+
+Alternatively, you can use the GUI provided by ASPEN to process Level_0 to Level_1. ``pydropsonde`` won't reprocess Level_1 if the respective files are already available.


### PR DESCRIPTION
This PR updates the pydropsonde documentation and respectively only touches files in the `/docs` folder. 
Mostly, it rearranges sections, adds links, and content. 

Two points where I am unsure would be happy to get feedback on are:
1. the toc tree entry below `Data` shows not the subheadings, but links to the data levels. Does that make sense?
2. `Getting started` is split into 3 subpages. Should we merge it again? The config file info became lengths such that I split it all up into subpages.

And it would be great if someone could check especially the statements on default behaviours.