### PR TITLE
Remove interpolation

### DIFF
--- a/pydropsonde/helper/__init__.py
+++ b/pydropsonde/helper/__init__.py
@@ -310,7 +310,7 @@ def calc_rh_from_q(ds):
             standard_name="relative_humidity",
             long_name="relative humidity",
             units="1",
-            method=f"recalculated from q following {es_name} after interpolation",
+            method=f"recalculated from q following {es_name} after binning",
         )
     ds = ds.assign(rh=(ds.q.dims, rh, rh_attrs))
 

--- a/pydropsonde/helper/__init__.py
+++ b/pydropsonde/helper/__init__.py
@@ -310,7 +310,7 @@ def calc_rh_from_q(ds):
             standard_name="relative_humidity",
             long_name="relative humidity",
             units="1",
-            method=f"recalculated from q following {es_name}",
+            method=f"recalculated from q following {es_name} after interpolation",
         )
     ds = ds.assign(rh=(ds.q.dims, rh, rh_attrs))
 
@@ -375,6 +375,7 @@ def calc_theta_from_T(ds):
             long_name="potential temperature",
             units="kelvin",
         )
+    theta_attrs.update(dict(method="calculated from measured ta and p"))
     ds = ds.assign(theta=(ds.ta.dims, theta, theta_attrs))
 
     return ds
@@ -403,6 +404,8 @@ def calc_T_from_theta(ds):
             long_name="air temperature",
             units="K",
         )
+
+    t_attrs.update(dict(method="recalculated from theta and p after interpolation"))
     ds = ds.assign(ta=(ds.theta.dims, ta, t_attrs))
     return ds
 

--- a/pydropsonde/helper/__init__.py
+++ b/pydropsonde/helper/__init__.py
@@ -405,7 +405,7 @@ def calc_T_from_theta(ds):
             units="K",
         )
 
-    t_attrs.update(dict(method="recalculated from theta and p after interpolation"))
+    t_attrs.update(dict(method="recalculated from theta and p after binning"))
     ds = ds.assign(ta=(ds.theta.dims, ta, t_attrs))
     return ds
 

--- a/pydropsonde/pipeline.py
+++ b/pydropsonde/pipeline.py
@@ -549,7 +549,6 @@ pipeline = {
             "add_attributes_as_var",
             "make_attr_coordinates",
             "add_qc_to_interim_l3",
-            "get_N_m_values",
             "add_Nm_to_vars",
             "add_globals_l3",
             "add_expected_coords",

--- a/tests/test_lev3.py
+++ b/tests/test_lev3.py
@@ -139,6 +139,7 @@ class TestGroup:
             interp_step=10,
             max_gap_fill=int(20),
             p_log=True,
+            interpolate=True,
             method="bin",
         )
 
@@ -156,11 +157,16 @@ class TestGroup:
         print(new_sonde.interim_l3_ds)
 
         assert not np.any(np.abs(result_ds.p - new_sonde.interim_l3_ds.p) > 1e-6)
-        assert result_ds.drop_vars("p").equals(new_sonde.interim_l3_ds.drop_vars("p"))
+        assert result_ds.drop_vars("p").equals(
+            new_sonde.interim_l3_ds.drop_vars(
+                ["p", "q_N_qc", "p_N_qc", "q_m_qc", "p_m_qc"]
+            )
+        )
         self.interp_sonde = new_sonde
 
     def test_N_m(self, sonde_interp, test_input, expected):
-        new_sonde = self.interp_sonde.get_N_m_values()
+        new_sonde = self.interp_sonde
         print(new_sonde.interim_l3_ds)
+        print(expected["Nq"])
         assert np.all(new_sonde.interim_l3_ds["q_N_qc"].values == expected["Nq"])
         assert np.all(new_sonde.interim_l3_ds["q_m_qc"].values == expected["mq"])


### PR DESCRIPTION
remove 50m - interpolation from level 3. (it can still be added with the keyword).
we want to remove the interpolation since we will do some custom interpolation for the circle products and if people want to do a simple linear interpolation in level 3 that's a one-liner with xarray. but like this, level 3 only contains data that is actually measured (even if binned and averaged).