### PR TITLE
Add circle interpolation

### DIFF
--- a/pydropsonde/circles.py
+++ b/pydropsonde/circles.py
@@ -220,7 +220,7 @@ class Circle:
 
     def apply_fit2d(self, variables=None):
         if variables is None:
-            variables = ["u", "v", "q", "ta", "p", "density"]
+            variables = ["u", "v", "q", "ta", "p", "rh", "theta"]
         alt_var = self.alt_dim
         alt_attrs = self.circle_ds[alt_var].attrs
 

--- a/pydropsonde/pipeline.py
+++ b/pydropsonde/pipeline.py
@@ -609,7 +609,6 @@ pipeline = {
         "intake": "gridded",
         "apply": iterate_Circle_method_over_dict_of_Circle_objects,
         "functions": [
-            "add_density",
             "apply_fit2d",
             "add_divergence",
             "add_vorticity",
@@ -632,6 +631,7 @@ pipeline = {
         "intake": "gridded",
         "apply": apply_method_to_dataset,
         "functions": [
+            "drop_vars",
             "get_l4_dir",
             "get_l4_filename",
             "update_history_l4",

--- a/pydropsonde/pipeline.py
+++ b/pydropsonde/pipeline.py
@@ -601,7 +601,11 @@ pipeline = {
     "prepare_circle_dataset": {
         "intake": "gridded",
         "apply": iterate_Circle_method_over_dict_of_Circle_objects,
-        "functions": ["get_xy_coords_for_circles"],
+        "functions": [
+            "get_xy_coords_for_circles",
+            "drop_vars",
+            "interpolate_na_sondes",
+        ],
         "output": "gridded",
         "comment": "prepare circle dataset for calculation",
     },
@@ -614,7 +618,6 @@ pipeline = {
             "add_vorticity",
             "add_omega",
             "add_wvel",
-            "drop_vars",
             "add_circle_variables_to_ds",
         ],
         "output": "gridded",
@@ -631,7 +634,6 @@ pipeline = {
         "intake": "gridded",
         "apply": apply_method_to_dataset,
         "functions": [
-            "drop_vars",
             "get_l4_dir",
             "get_l4_filename",
             "update_history_l4",


### PR DESCRIPTION
adds possibility to interpolate sonde profiles before calculating the circle variables
- if fewer than four values are measured by a sonde it is omitted altogether
- density is removed from the pipeline as it is not longer needed.
(rebased on PR #177  )

