### PR TITLE
detect minisondes and apply minisonde profile in aspen

### DIFF
--- a/pydropsonde/helper/paths.py
+++ b/pydropsonde/helper/paths.py
@@ -169,6 +169,7 @@ class Flight:
                 launch_time = "UNKNOWN"
             Sondes[sonde_id] = Sonde(_serial_id=sonde_id, _launch_time=launch_time)
             Sondes[sonde_id].add_launch_detect(launch_detect)
+            Sondes[sonde_id].sonde_rev = rr.get_sonde_rev(a_file)
             Sondes[sonde_id].add_flight_id(
                 self.flight_id,
                 config.get(

--- a/pydropsonde/helper/rawreader.py
+++ b/pydropsonde/helper/rawreader.py
@@ -4,7 +4,7 @@ Module to read from raw files, mostly to gather metadata from A files
 
 from datetime import datetime
 import logging
-from typing import List
+from typing import List, Optional
 import os
 import fsspec
 import yaml
@@ -89,6 +89,17 @@ def get_sonde_id(a_file: "str") -> str:
     except UnboundLocalError:
         afile_base = os.path.basename(a_file)
         return afile_base.split(".")[0][1:]
+
+
+def get_sonde_rev(a_file: str) -> Optional[str]:
+    with open(a_file, "r") as f:
+        module_logger.debug(f"Opened File: {a_file=}")
+
+        for i, line in enumerate(f):
+            if "Sonde ID/Type/Rev" in line:
+                module_logger.debug(f'"Sonde ID/Type/Rev" found on line {i=}')
+                return line.split(":")[1].split(",")[2].lstrip()
+    return None
 
 
 def get_launch_time(a_file: "str") -> np.datetime64:


### PR DESCRIPTION
This change will automatically detect minisondes and will run the aspen CLI with the mini-dropsonde profile in these cases.

I have to admit, that I didn't see where to best put a test in the current testing framework and would be happy about ideas. My (manual) test so far was running the pipeline and checking that L1 data is generated (not 0-bytes) and that the profiles look reasonable (e.g. altitude starts at 0).

I'm not yet super happy with how `get_sonde_rev` works (it reads the `a_file` again), but I tried to stick to the surrounding style, it seems like the `a_file` is opened many times already.

I skipped defining `add_sonde_rev`, getter and `_sonde_rev` implementations, as there doesn't seem to be a technical benefit in doing so. But that disagrees with the current style. Would it be better otherwise?