### PR TITLE
sort by time for qc

### DIFF
--- a/pydropsonde/helper/quality.py
+++ b/pydropsonde/helper/quality.py
@@ -32,10 +32,10 @@ class QualityControl:
             self.qc_by_var.update({variable: dict(qc_flags={}, qc_details={})})
 
     def set_qc_ds(self, ds):
-        if "alt" in self.alt_dim:
-            self.qc_ds = ds.sortby(self.alt_dim, ascending=False)
+        if "time" in ds.dims:
+            self.qc_ds = ds.sortby("time")
         else:
-            self.qc_ds = ds.sortby(self.alt_dim)
+            self.qc_ds = ds.sortby(self.alt_dim, ascending=False)
 
     def get_is_floater(
         self,
@@ -179,7 +179,7 @@ class QualityControl:
 
 
         """
-        ds = self.qc_ds
+        ds = self.qc_ds.sortby(time_dimension)
         var_keys = set(variable_dict.keys())
         if set(var_keys) != set(self.qc_vars.keys()):
             var_keys = set(var_keys) & set(self.qc_vars.keys())

--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -50,10 +50,12 @@ def qc_vars(qc):
 
 
 def test_profile_sparsity(qc_vars):
-    qc_vars.profile_sparsity(variable_dict={"q": 2, "p": 2, "rh": 4})
+    qc_vars.profile_sparsity(variable_dict={"q": 2, "p": 4, "rh": 4})
     assert qc_vars.qc_flags["p_profile_sparsity"]
     assert qc_vars.qc_flags["q_profile_sparsity"]
     assert not qc_vars.qc_flags["rh_profile_sparsity"]
+    assert qc_vars.qc_details["p_profile_sparsity_fraction"] >= 0
+    assert qc_vars.qc_details["rh_profile_sparsity_fraction"] >= 0
 
 
 def test_near_surface(qc_vars):


### PR DESCRIPTION
for the sparsity test, the qc dataset has to be sorted by time. otherwise negative values can occur