### PR TITLE
Change l3 structure

### DIFF
--- a/dropsonde.cfg
+++ b/dropsonde.cfg
@@ -14,9 +14,6 @@ skip=True
 [processor.Sonde.add_qc_to_interim_l3]
 keep=all
 
-[processor.Gridded.drop_qc_vars]
-keep=all
-
 [processor.Gridded.get_l3_filename]
 l3_filename = Level_3.zarr
 

--- a/pydropsonde/circles.py
+++ b/pydropsonde/circles.py
@@ -132,7 +132,7 @@ class Circle:
             ),
             circle_time=(
                 [],
-                self.circle_ds["launch_time"].mean().values,
+                self.circle_ds["sonde_time"].mean().values,
                 circle_time_attrs,
             ),
             circle_lon=([], self.clon, circle_lon_attrs),

--- a/pydropsonde/circles.py
+++ b/pydropsonde/circles.py
@@ -23,6 +23,7 @@ class Circle:
     platform_id: str
     segment_id: str
     alt_dim: str
+    sonde_dim: str
 
     def drop_m_N_vars(self):
         """
@@ -137,8 +138,8 @@ class Circle:
             circle_lon=([], self.clon, circle_lon_attrs),
             circle_lat=([], self.clat, circle_lat_attrs),
             circle_radius=([], self.crad, circle_radius_attrs),
-            x=(["sonde_id", self.alt_dim], delta_x.values, delta_x_attrs),
-            y=(["sonde_id", self.alt_dim], delta_y.values, delta_y_attrs),
+            x=([self.sonde_dim, self.alt_dim], delta_x.values, delta_x_attrs),
+            y=([self.sonde_dim, self.alt_dim], delta_y.values, delta_y_attrs),
         )
 
         self.circle_ds = self.circle_ds.assign(new_vars)
@@ -157,7 +158,7 @@ class Circle:
 
         return intercept, dux, duy
 
-    def fit2d_xr(self, x, y, u, sonde_dim="sonde_id"):
+    def fit2d_xr(self, x, y, u, sonde_dim="sonde"):
         return xr.apply_ufunc(
             self.__class__.fit2d,  # Call the static method without passing `self`
             x,
@@ -199,7 +200,7 @@ class Circle:
                 x=self.circle_ds.x,
                 y=self.circle_ds.y,
                 u=self.circle_ds[par],
-                sonde_dim="sonde_id",
+                sonde_dim=self.sonde_dim,
             )
 
             for varname, result, long_name, use_name in zip(
@@ -230,7 +231,7 @@ class Circle:
         self.circle_ds = ds
         return self
 
-    def add_density(self, sonde_dim="sonde_id", alt_dim="gpsalt"):
+    def add_density(self):
         """
         Calculate and add the density to the circle dataset.
 

--- a/pydropsonde/helper/__init__.py
+++ b/pydropsonde/helper/__init__.py
@@ -111,7 +111,7 @@ l2_flight_attributes_map = {
 }
 
 l3_coords = dict(
-    launch_time={"long_name": "dropsonde launch time", "time_zone": "UTC"},
+    sonde_time={"long_name": "dropsonde launch time", "time_zone": "UTC"},
     aircraft_longitude={
         "long_name": "aircraft longitude at launch",
         "units": "degrees_east",

--- a/pydropsonde/helper/__init__.py
+++ b/pydropsonde/helper/__init__.py
@@ -53,7 +53,7 @@ l2_variables = {
         "attributes": {
             "standard_name": "latitude",
             "long_name": "latitude",
-            "units": "degree_north",
+            "units": "degrees_north",
             "axis": "Y",
         },
     },
@@ -62,7 +62,7 @@ l2_variables = {
         "attributes": {
             "standard_name": "longitude",
             "long_name": "longitude",
-            "units": "degree_east",
+            "units": "degrees_east",
             "axis": "X",
         },
     },
@@ -104,16 +104,22 @@ l2_flight_attributes_map = {
     "Format Notes": "AVAPS_format_notes",
     "True Heading (deg)": "true_heading_(deg)",
     "Ground Track (deg)": "ground_track_(deg)",
-    "Longitude (deg)": "aircraft_longitude_(deg_E)",
-    "Latitude (deg)": "aircraft_latitude_(deg_N)",
+    "Longitude (deg)": "aircraft_longitude_(degrees_east)",
+    "Latitude (deg)": "aircraft_latitude_(degrees_north)",
     "MSL Altitude (m)": "aircraft_msl_altitude_(m)",
     "Geopotential Altitude (m)": "aircraft_geopotential_altitude_(m)",
 }
 
 l3_coords = dict(
     launch_time={"long_name": "dropsonde launch time", "time_zone": "UTC"},
-    aircraft_longitude={"long_name": "aircraft longitude at launch", "units": "deg_E"},
-    aircraft_latitude={"long_name": "aircraft latitude at launch", "units": "deg_N"},
+    aircraft_longitude={
+        "long_name": "aircraft longitude at launch",
+        "units": "degrees_east",
+    },
+    aircraft_latitude={
+        "long_name": "aircraft latitude at launch",
+        "units": "degrees_north",
+    },
     aircraft_msl_altitude={"long_name": "aircraft altitude at launch", "units": "m"},
 )
 

--- a/pydropsonde/helper/xarray_helper.py
+++ b/pydropsonde/helper/xarray_helper.py
@@ -37,11 +37,21 @@ def get_chunks(ds, var, object_dim="sonde_id", alt_dim="alt"):
     """
     get standard chunks for one object_dim (like sonde_id or circle_id) and one height dimension
     """
-    chunks = {
-        object_dim: min(256, ds.sonde_id.size),
-        alt_dim: min(400, ds[alt_dim].size),
-    }
-
+    if object_dim not in ds[var].dims:
+        chunks = {
+            object_dim: 1,
+            alt_dim: ds[alt_dim].size,
+        }
+    elif alt_dim not in ds[var].dims:
+        chunks = {
+            object_dim: ds[object_dim].size,
+            alt_dim: 1,
+        }
+    else:
+        chunks = {
+            object_dim: min(750, ds[object_dim].size),
+            alt_dim: min(750, ds[alt_dim].size),
+        }
     return tuple((chunks[d] for d in ds[var].dims))
 
 

--- a/pydropsonde/pipeline.py
+++ b/pydropsonde/pipeline.py
@@ -257,8 +257,8 @@ def create_and_populate_circle_object(
     circles = {}
 
     for segment in gridded.segments:
-        extra_sondes = gridded.l3_ds.sel(
-            sonde_id=gridded.l3_ds.sonde_id.isin(segment.get("extra_sondes"))
+        extra_sondes = gridded.l3_ds.where(
+            gridded.l3_ds["sonde_id"].isin(segment.get("extra_sondes")), drop=True
         )
 
         circle_ds = gridded.l3_ds.where(
@@ -268,7 +268,7 @@ def create_and_populate_circle_object(
         )
         circle_ds = xr.concat(
             [circle_ds, extra_sondes],
-            dim="sonde_id",
+            dim=gridded.sonde_dim,
             join="exact",
             combine_attrs="no_conflicts",
         )
@@ -279,6 +279,7 @@ def create_and_populate_circle_object(
                 platform_id=segment["platform_id"],
                 segment_id=segment["segment_id"],
                 alt_dim=gridded.alt_dim,
+                sonde_dim=gridded.sonde_dim,
                 clon=segment.get("clon"),
                 clat=segment.get("clat"),
                 crad=segment.get("radius"),
@@ -581,7 +582,7 @@ pipeline = {
             "check_pydropsonde_version",
             "check_broken",
             "add_history_to_ds",
-            "add_alt_dim",
+            "add_dim_names",
             "concat_sondes",
             "get_l3_dir",
             "get_l3_filename",

--- a/pydropsonde/pipeline.py
+++ b/pydropsonde/pipeline.py
@@ -262,8 +262,8 @@ def create_and_populate_circle_object(
         )
 
         circle_ds = gridded.l3_ds.where(
-            (gridded.l3_ds["launch_time"] > np.datetime64(segment["start"]))
-            & (gridded.l3_ds["launch_time"] < np.datetime64(segment["end"])),
+            (gridded.l3_ds["sonde_time"] > np.datetime64(segment["start"]))
+            & (gridded.l3_ds["sonde_time"] < np.datetime64(segment["end"])),
             drop=True,
         )
         circle_ds = xr.concat(

--- a/pydropsonde/processor.py
+++ b/pydropsonde/processor.py
@@ -1876,7 +1876,12 @@ class Gridded:
             sortby = list(hh.l3_coords.keys())[0]
         list_of_l2_ds = [sonde.interim_l3_ds for sonde in self.sondes.values()]
         try:
-            ds = xr.concat(list_of_l2_ds, dim="sonde_id", join="exact").sortby(sortby)
+            ds = xr.concat(
+                list_of_l2_ds,
+                dim="sonde_id",
+                join="exact",
+                combine_attrs="drop_conflicts",
+            ).sortby(sortby)
         except AttributeError:
             if coords is None:
                 coords = hh.l3_coords
@@ -1892,7 +1897,12 @@ class Gridded:
                         for coord in missing_coords
                     }
                 )
-            ds = xr.concat(list_of_l2_ds, dim="sonde_id", join="exact").sortby(sortby)
+            ds = xr.concat(
+                list_of_l2_ds,
+                dim="sonde_id",
+                join="exact",
+                combine_attrs="drop_conflicts",
+            ).sortby(sortby)
 
         if hasattr(self, "global_attrs"):
             ds = ds.assign_attrs(self.global_attrs)

--- a/pydropsonde/processor.py
+++ b/pydropsonde/processor.py
@@ -708,7 +708,7 @@ class Sonde:
         """
         sonde_attrs = {
             "platform_id": self.platform_id,
-            "launch_time_(UTC)": (
+            "sonde_time": (
                 str(self.aspen_ds.launch_time.values)
                 if hasattr(self.aspen_ds, "launch_time")
                 else np.datetime64(self.aspen_ds.base_time.values)
@@ -1555,7 +1555,7 @@ class Sonde:
                 essential_attrs = hh.l3_coords
             except AttributeError:
                 essential_attrs = {
-                    "launch_time": {
+                    "sonde_time": {
                         "time_zone": "UTC",
                         "long_name": "dropsonde launch time",
                     }
@@ -1569,13 +1569,12 @@ class Sonde:
                 ds = ds.assign(
                     {var_name: (self.sonde_dim, [l2_ds.attrs[attr]], var_attrs)}
                 )
-
         ds = ds.assign(
             dict(
-                launch_time=(
+                sonde_time=(
                     self.sonde_dim,
-                    ds.launch_time.astype(np.datetime64).values,
-                    essential_attrs["launch_time"],
+                    [np.datetime64(self.launch_time, "ns")],
+                    essential_attrs["sonde_time"],
                 )
             )
         )

--- a/pydropsonde/processor.py
+++ b/pydropsonde/processor.py
@@ -742,7 +742,7 @@ class Sonde:
             "long_name": "sonde identifier",
             "cf_role": "trajectory_id",
         }
-        ds = ds.assign_coords({variable_name: self.serial_id})
+        ds = ds.assign({variable_name: self.serial_id})
         ds[variable_name] = ds[variable_name].assign_attrs(attrs)
         self.interim_l2_ds = ds
 
@@ -771,7 +771,7 @@ class Sonde:
             description="unique platform ID",
             long_name="platform identifier",
         )
-        ds = ds.assign_coords({variable_name: self.platform_id})
+        ds = ds.assign({variable_name: self.platform_id})
         ds[variable_name] = ds[variable_name].assign_attrs(attrs)
         self.interim_l2_ds = ds
         return self
@@ -800,7 +800,7 @@ class Sonde:
             long_name="flight identifier",
         )
 
-        ds = ds.assign_coords({variable_name: self.flight_id})
+        ds = ds.assign({variable_name: self.flight_id})
         ds[variable_name] = ds[variable_name].assign_attrs(attrs)
         self.interim_l2_ds = ds
         return self
@@ -1519,7 +1519,7 @@ class Sonde:
         """
         ds = self.interim_l3_ds
         source_ds = self.l2_ds
-        self.interim_l3_ds = ds.assign_coords(
+        self.interim_l3_ds = ds.assign(
             {
                 "sonde_id": (
                     "sonde_id",


### PR DESCRIPTION
This should address the issues mentioned in #102 for level 3.

I.e: 
- the sonde-dimension in level 3 now does not have a coordinate, it is just "sonde"
- the `launch_time` is renamed to `sonde_time` to be consistent with `circle_time` in level 4
- `sonde_id`, `platform_id` and `flight_id` are now variables as to not have string-type coordinates
- units for latitude and longitude variables are corrected
- the chunksize is adapted because chunks were super small in L3 
- when concatenating l2 drop non-matching conflicts 