### PR TITLE
fix time encoding to resolve dates now and in the future

### DIFF
--- a/pydropsonde/helper/xarray_helper.py
+++ b/pydropsonde/helper/xarray_helper.py
@@ -73,7 +73,7 @@ def get_target_dtype(ds, var):
     if isinstance(ds[var].values.flat[0], np.floating):
         return {"dtype": "float32"}
     if np.issubdtype(type(ds[var].values.flat[0]), np.datetime64):
-        return {"units": "nanoseconds since 2000-01-01", "dtype": "float32"}
+        return {"units": "nanoseconds since 2000-01-01", "dtype": "<i8"}
     else:
         return {"dtype": ds[var].values.dtype}
 


### PR DESCRIPTION
the previous implementation with `float32` could not resolve dates at nanosecond resolution. This PR changes it to `<i8` such that campaign data also in 100 years from now could be processed :)