### PR TITLE
Rename and drop interp time

### DIFF
--- a/pydropsonde/circles.py
+++ b/pydropsonde/circles.py
@@ -25,10 +25,17 @@ class Circle:
     alt_dim: str
     sonde_dim: str
 
-    def drop_m_N_vars(self):
+    def drop_vars(self, variables=None):
         """
         drop m and N variables from level 3 from circle dataset
         """
+        if variables is None:
+            variables = [
+                "bin_average_time",
+                "alt_near_gpsalt",
+                "alt_source",
+                "alt_near_gpsalt_max_diff",
+            ]
         ds = self.circle_ds
         ds = (
             ds.drop_vars(
@@ -42,7 +49,26 @@ class Circle:
             .drop_vars(
                 ["gps_m_qc", "gps_N_qc", "gpspos_N_qc", "gpspos_m_qc"], errors="ignore"
             )
+            .drop_vars(
+                [f"{var}_qc" for var in ["u", "v", "ta", "p", "rh"]],
+                errors="ignore",
+            )
+            .drop_vars(
+                variables,
+                errors="ignore",
+            )
         )
+        for qc_details in [
+            "low_physics_sfc",
+            "near_surface_count",
+            "profile_extent_max",
+            "profile_sparsity_fraction",
+        ]:
+            ds = ds.drop_vars(
+                [f"{var}_{qc_details}" for var in ["u", "v", "ta", "p", "rh"]],
+                errors="ignore",
+            )
+
         self.circle_ds = ds
 
         return self

--- a/pydropsonde/helper/__init__.py
+++ b/pydropsonde/helper/__init__.py
@@ -279,7 +279,7 @@ def calc_q_from_rh(ds):
     return ds
 
 
-def calc_rh_from_q(ds):
+def calc_rh_from_q(ds, alt_dim="altitude"):
     """
     Input :
 
@@ -308,7 +308,7 @@ def calc_rh_from_q(ds):
             standard_name="relative_humidity",
             long_name="relative humidity",
             units="1",
-            method=f"recalculated from q following {es_name} after binning",
+            method=f"recalculated from q following {es_name} after binning in {alt_dim}",
         )
     ds = ds.assign(rh=(ds.q.dims, rh, rh_attrs))
 
@@ -385,7 +385,7 @@ def calc_theta_from_T(ds):
     return ds
 
 
-def calc_T_from_theta(ds):
+def calc_T_from_theta(ds, alt_dim="altitude"):
     """
     Input :
 
@@ -409,7 +409,9 @@ def calc_T_from_theta(ds):
             units="K",
         )
 
-    t_attrs.update(dict(method="recalculated from theta and p after binning"))
+    t_attrs.update(
+        dict(method=f"recalculated from theta and p after binning in {alt_dim}")
+    )
     ds = ds.assign(ta=(ds.theta.dims, ta, t_attrs))
     return ds
 

--- a/pydropsonde/pipeline.py
+++ b/pydropsonde/pipeline.py
@@ -601,7 +601,7 @@ pipeline = {
     "prepare_circle_dataset": {
         "intake": "gridded",
         "apply": iterate_Circle_method_over_dict_of_Circle_objects,
-        "functions": ["drop_m_N_vars", "get_xy_coords_for_circles"],
+        "functions": ["get_xy_coords_for_circles"],
         "output": "gridded",
         "comment": "prepare circle dataset for calculation",
     },
@@ -615,6 +615,7 @@ pipeline = {
             "add_vorticity",
             "add_omega",
             "add_wvel",
+            "drop_vars",
         ],
         "output": "gridded",
         "comment": "calculate circle products",

--- a/pydropsonde/processor.py
+++ b/pydropsonde/processor.py
@@ -1359,11 +1359,13 @@ class Sonde:
                 interp_ds = interp_ds.rename({f"{alt_dim}_bin": alt_dim})
             interp_ds[alt_dim].attrs.update(ds[alt_dim].attrs)
             time_type = ds["time"].values.dtype
+            time_attrs = interp_ds.time.attrs
+            time_attrs.update({"long_name": f"time after binning in {alt_dim}"})
             interp_ds = interp_ds.assign(
-                interp_time=(
+                bin_average_time=(
                     interp_ds.time.dims,
                     interp_ds.time.astype(time_type).values,
-                    interp_ds.time.attrs,
+                    time_attrs,
                 )
             ).drop_vars("time")
 

--- a/tests/test_lev3.py
+++ b/tests/test_lev3.py
@@ -148,7 +148,7 @@ class TestGroup:
             "data_vars": {
                 "q": {"dims": ("alt"), "data": expected["q"]},
                 "p": {"dims": ("alt"), "data": expected["p"]},
-                "interp_time": {"dims": ("alt"), "data": expected["time"]},
+                "bin_average_time": {"dims": ("alt"), "data": expected["time"]},
             },
         }
         result_ds = xr.Dataset.from_dict(res_dict)


### PR DESCRIPTION
- rename interp time to `bin_average_time` (#172)
- add altitude details to bin attributes
- drop `bin_average_time` and qc variables from L4

Close #172 