### PR TITLE
make iterate methods more flexible

### DIFF
--- a/pydropsonde/pipeline.py
+++ b/pydropsonde/pipeline.py
@@ -49,8 +49,8 @@ def get_mandatory_args(function):
     """
     mandatory_args = []
     sig = inspect.signature(function)
-    for name, param in sig.parameters.items():
-        if param.default == inspect.Parameter.empty and name != "self":
+    for name, param in list(sig.parameters.items())[1:]:
+        if param.default == inspect.Parameter.empty:
             mandatory_args.append(name)
     return mandatory_args
 

--- a/pydropsonde/pipeline.py
+++ b/pydropsonde/pipeline.py
@@ -115,7 +115,11 @@ def get_nondefaults_from_config(
         A dictionary of non-default arguments for the function.
     """
 
-    section_name = f"{obj.__module__}.{obj.__qualname__}".split("pydropsonde.")[1]
+    try:
+        section_name = f"{obj.__module__}.{obj.__qualname__}".split("pydropsonde.")[1]
+    except IndexError:
+        section_name = None
+
     if section_name in config.sections():
         nondefault_args = config[section_name]
     else:

--- a/pydropsonde/pipeline.py
+++ b/pydropsonde/pipeline.py
@@ -333,7 +333,7 @@ def iterate_Sonde_method_over_dict_of_Sondes_objects(
                     new_dict[key] = result
             else:
                 new_dict[key] = value
-            my_dict = new_dict.copy()
+        my_dict = new_dict
     return my_dict
 
 

--- a/pydropsonde/pipeline.py
+++ b/pydropsonde/pipeline.py
@@ -378,7 +378,7 @@ def iterate_Circle_method_over_dict_of_Circle_objects(
             if result is not None:
                 new_dict[key] = result
 
-            my_dict = new_dict
+        my_dict = new_dict
 
     obj.circles.update(my_dict)
     return obj

--- a/tests/test_inspect_function.py
+++ b/tests/test_inspect_function.py
@@ -9,8 +9,7 @@ from pydropsonde.pipeline import (
 
 
 # Define a function for testing
-@pytest.fixture
-def test_func(a, b=2):
+def some_func(self, a, b=2):
     pass
 
 
@@ -18,14 +17,14 @@ def test_func(a, b=2):
 def config_and_function():
     # Create a ConfigParser object and add a section for the test function
     config = configparser.ConfigParser()
-    config.add_section("test_inspect_function.test_func")
-    config.set("test_inspect_function.test_func", "b", "3")
+    config.add_section("test_inspect_function.some_func")
+    config.set("test_inspect_function.some_func", "b", "3")
     config.add_section("MANDATORY")
     config.set("MANDATORY", "a", "1")
 
-    if "pydropsonde" not in test_func.__module__:
-        test_func.__module__ = f"pydropsonde.{test_func.__module__}"
-    return config, test_func
+    if "pydropsonde" not in some_func.__module__:
+        some_func.__module__ = f"pydropsonde.{some_func.__module__}"
+    return config, some_func
 
 
 def test_get_mandatory_args(config_and_function):

--- a/tests/test_iteration.py
+++ b/tests/test_iteration.py
@@ -1,0 +1,29 @@
+import pytest
+from pydropsonde.pipeline import iterate_Sonde_method_over_dict_of_Sondes_objects
+from pydropsonde.processor import Sonde
+import configparser
+
+config = configparser.ConfigParser()
+config.add_section("MANDATORY")
+config.set("MANDATORY", "a", "1")
+
+
+@pytest.fixture
+def sonde_dict():
+    return {i: Sonde(str(i)) for i in range(3)}
+
+
+def test_sonde_iterator(sonde_dict):
+    res = []
+
+    def collect_sonde_serial_id(sonde: Sonde) -> Sonde:
+        res.append(sonde.serial_id)
+        return sonde
+
+    sonde_dict = iterate_Sonde_method_over_dict_of_Sondes_objects(
+        obj=sonde_dict,
+        functions=[collect_sonde_serial_id],
+        config=config,
+    )
+    assert res == ["0", "1", "2"]
+    assert len(sonde_dict) == 3


### PR DESCRIPTION
This PR fixes a potential bug in the `iterate_Sonde_...` and `iterate_Circle_...` methods and more importent, extends those to handle functions from outside the respective classes:

1. there seems to be an unintended overwrite in the loop over sonde/circle objects in `interate_Sonde_method_over_dict_of_[Sondes/Circles]_object` due to a wrong indentation. Might be more robust to overwrite `my_dict` at the end of an applied "method".
2. the methods are extended to handle not only strings, but also callables with the idea that you can include functions from outside the `Sonde` and `Circle` class, too.