### PR TITLE
add QR code generator for pydropsonde

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -14,8 +14,10 @@ dependencies:
   - netcdf4
   - numpy
   - openssl
+  - pillow
   - pre-commit
   - pytest
+  - qrcode
   - requests
   - sphinx
   - sphinx-autobuild

--- a/make_qrcode.py
+++ b/make_qrcode.py
@@ -1,0 +1,42 @@
+# import io
+import subprocess
+import qrcode
+
+# from cairosvg import svg2png
+from PIL import Image
+
+
+def _main():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--url",
+        default="https://github.com/atmdrops/pydropsonde",
+        help="URL behind the QRcode pointing to pydropsonde repo or docu",
+    )
+    parser.add_argument("--logo", default=None, help="Logo image to be embedded")
+    parser.add_argument("--ofile", default="qrcode.png", help="output file name")
+    args = parser.parse_args()
+
+    img = qrcode.make(args.url)
+
+    if args.logo:
+        print(f"Embedding logo: {args.logo}")
+        img = img.convert("RGBA")
+        if args.logo.endswith(".svg"):
+            logo_png = args.logo[:-3] + "png"
+            subprocess.run(["magick", args.logo, logo_png])
+            logo = Image.open(logo_png)
+        else:
+            logo = Image.open(args.logo)
+        img.alpha_composite(
+            logo, ((img.size[0] - logo.size[0]) // 2, (img.size[1] - logo.size[1]) // 2)
+        )
+        subprocess.run(["rm", logo_png])
+
+    img.save(args.ofile, "PNG")
+
+
+if __name__ == "__main__":
+    _main()


### PR DESCRIPTION
I thought of adding a script that generates a QR code pointing to `pydropsonde`.
At this stage, only the default works well, the optional logo embedded as image in the QR code does not work yet as I couldn't find an elegant way to convert `svg` images to a format that pillow can handle (currently it's assumed that imagemagick is installed on your machine) and also, the current default logo is too large and covers the full QR code.
If someone has an idea, let me know :)

Maybe it would be even nice to include such a script in the workflows and point to e.g. the latest release?