### PR TITLE
update aspen docker image version to 4.0.4

### DIFF
--- a/pydropsonde/processor.py
+++ b/pydropsonde/processor.py
@@ -269,7 +269,7 @@ class Sonde:
                     f"type=bind,source={l0_dir},target=/input",
                     "--mount",
                     f"type=bind,source={l1_dir},target=/output",
-                    "ghcr.io/atmdrops/aspenqc:4.0.2",
+                    "ghcr.io/atmdrops/aspenqc:4.0.4",
                     "-i",
                     f"/input/{dname}",
                     "-n",


### PR DESCRIPTION
A new Aspen version is available as of May 5. It has several improvements that are listed in the respective [PR in the aspenqc repository](https://github.com/atmdrops/aspenqc/pull/4). It seems reasonable to update pydropsonde to the latest release, too.