### PR TITLE
Rename vars

### DIFF
--- a/pydropsonde/circles.py
+++ b/pydropsonde/circles.py
@@ -294,8 +294,8 @@ class Circle:
                 "p",
                 "rh",
                 "theta",
-                "w_dir",
-                "w_spd",
+                "wdir",
+                "wspd",
                 "iwv",
             ]
         alt_var = self.alt_dim
@@ -511,7 +511,7 @@ class Circle:
 
     def drop_dvardxy(self, variables=None):
         if variables is None:
-            variables = ["iwv", "p", "rh", "q", "ta", "theta", "w_spd", "w_dir"]
+            variables = ["iwv", "p", "rh", "q", "ta", "theta", "wspd", "wdir"]
         self.circle_ds = self.circle_ds.drop_vars(
             [f"{var}_d{var}dx" for var in variables],
             errors="ignore",

--- a/pydropsonde/circles.py
+++ b/pydropsonde/circles.py
@@ -195,7 +195,7 @@ class Circle:
                 ),
                 circle_time=(
                     [],
-                    self.circle_ds["sonde_time"].isel(sonde=[0, -1]).mean().values,
+                    self.circle_ds["launch_time"].isel(sonde=[0, -1]).mean().values,
                     circle_time_attrs,
                 ),
                 circle_lon=([], self.clon, circle_lon_attrs),

--- a/pydropsonde/circles.py
+++ b/pydropsonde/circles.py
@@ -376,7 +376,7 @@ class Circle:
         alt_dim = self.alt_dim
         sonde_dim = self.sonde_dim
         if variables is None:
-            variables = ["u", "v"]
+            variables = ["u", "v", "q", "ta", "p", "rh", "theta"]
         ds = self.circle_ds
 
         dx_denominator = ((ds.x - ds.x.mean(dim=sonde_dim)) ** 2).sum(dim=sonde_dim)
@@ -511,7 +511,7 @@ class Circle:
 
     def drop_dvardxy(self, variables=None):
         if variables is None:
-            variables = ["iwv", "p", "rh", "q", "ta", "theta", "wspd", "wdir"]
+            variables = ["iwv", "wspd", "wdir"]
         self.circle_ds = self.circle_ds.drop_vars(
             [f"{var}_d{var}dx" for var in variables],
             errors="ignore",

--- a/pydropsonde/helper/__init__.py
+++ b/pydropsonde/helper/__init__.py
@@ -471,7 +471,7 @@ def calc_wind_dir_and_speed(ds):
     w_spd = np.sqrt(ds.u.values**2 + ds.v.values**2)
 
     ds = ds.assign(
-        w_dir=(
+        wdir=(
             ds.u.dims,
             w_dir,
             dict(
@@ -483,7 +483,7 @@ def calc_wind_dir_and_speed(ds):
     )
 
     ds = ds.assign(
-        w_spd=(
+        wspd=(
             ds.u.dims,
             w_spd,
             dict(

--- a/pydropsonde/helper/__init__.py
+++ b/pydropsonde/helper/__init__.py
@@ -111,7 +111,7 @@ l2_flight_attributes_map = {
 }
 
 l3_coords = dict(
-    sonde_time={"long_name": "dropsonde launch time", "time_zone": "UTC"},
+    launch_time={"long_name": "dropsonde launch time", "time_zone": "UTC"},
     aircraft_longitude={
         "long_name": "aircraft longitude at launch",
         "units": "degrees_east",

--- a/pydropsonde/pipeline.py
+++ b/pydropsonde/pipeline.py
@@ -279,8 +279,8 @@ def create_and_populate_circle_object(
         )
 
         circle_ds = ds.where(
-            (ds["sonde_time"] >= np.datetime64(segment["start"]))
-            & (ds["sonde_time"] < np.datetime64(segment["end"])),
+            (ds["launch_time"] >= np.datetime64(segment["start"]))
+            & (ds["launch_time"] < np.datetime64(segment["end"])),
             drop=True,
         )
         circle_ds = xr.concat(
@@ -291,7 +291,7 @@ def create_and_populate_circle_object(
         )
         if circle_ds.sonde_id.size > 0:
             circle = Circle(
-                circle_ds=circle_ds.sortby("sonde_time"),
+                circle_ds=circle_ds.sortby("launch_time"),
                 flight_id=segment["flight_id"],
                 platform_id=segment["platform_id"],
                 segment_id=segment["segment_id"],

--- a/pydropsonde/processor.py
+++ b/pydropsonde/processor.py
@@ -730,7 +730,7 @@ class Sonde:
         """
         sonde_attrs = {
             "platform_id": self.platform_id,
-            "sonde_time": (
+            "launch_time": (
                 str(self.aspen_ds.launch_time.values)
                 if hasattr(self.aspen_ds, "launch_time")
                 else np.datetime64(self.aspen_ds.base_time.values)
@@ -1645,7 +1645,7 @@ class Sonde:
                 essential_attrs = hh.l3_coords
             except AttributeError:
                 essential_attrs = {
-                    "sonde_time": {
+                    "launch_time": {
                         "time_zone": "UTC",
                         "long_name": "dropsonde launch time",
                     }
@@ -1661,10 +1661,10 @@ class Sonde:
                 )
         ds = ds.assign(
             dict(
-                sonde_time=(
+                launch_time=(
                     self.sonde_dim,
                     [np.datetime64(self.launch_time, "ns")],
-                    essential_attrs["sonde_time"],
+                    essential_attrs["launch_time"],
                 )
             )
         )
@@ -1967,7 +1967,7 @@ class Gridded:
         data = []
         for circle in self.circles.values():
             circle_ds = circle.circle_ds
-            circle_ds = circle_ds.sortby("sonde_time")
+            circle_ds = circle_ds.sortby("launch_time")
 
             vars_sonde_dim = []
             vars_circle_dim = []
@@ -1978,7 +1978,7 @@ class Gridded:
                 else:
                     vars_circle_dim.append(var)
 
-            count.append(len(circle_ds.sonde_time))
+            count.append(len(circle_ds.launch_time))
             data.append(circle_ds)
 
         concatenated_sonde_ds = xr.concat(

--- a/pydropsonde/processor.py
+++ b/pydropsonde/processor.py
@@ -1160,7 +1160,7 @@ class Sonde:
         """
         self.interim_l3_ds = hh.calc_iwv(
             self.interim_l3_ds,
-            qc_var=["rh_qc", "ta_qc"],
+            qc_var=["rh_qc", "ta_qc", "p_qc"],
             alt_dim=self.alt_dim,
             sonde_dim=self.sonde_dim,
         )


### PR DESCRIPTION
This pull requests solves multiple minor requests:

- add d{var}dx and d{var}dy for theta, ta, q, rh, p to the dataset
- add a passed p_qc as a requirement to the iwv calculation, since p is also used
- rename variables such that they are closer to rapsody, i.e. 
            - w_dir and w_spd to wdir and wspd
            - sonde_time to launch_time