### PR TITLE
fix check for monotonically increasing altitude

### DIFF
--- a/pydropsonde/processor.py
+++ b/pydropsonde/processor.py
@@ -1312,7 +1312,7 @@ class Sonde:
         ds = self.interim_l3_ds
 
         diff_array = ds[alt_dim].sortby("time").dropna(dim="time").diff(dim="time")
-        if not np.all(diff_array < 0):
+        if not np.all(diff_array <= 0):
             warnings.warn(
                 f"your altitude for {self} on {self.launch_time} is not sorted."
             )


### PR DESCRIPTION
The function `remove_non_mono_incr_alt` in processor.py seems to have not covered the possibility that `diff_array` could be 0 if two consecutive measurements in time result in the same altitude. As this actually happened in one of the EUREC4A P3 cases and broke the processing, I'd suggest to handle all possible cases by simply allowing `diff_array <= 0` as I think it's a reasonable measurement point that we would like to include if it happened at the same altitude than the time step before.