### PR TITLE
Coarsen time

### DIFF
--- a/pydropsonde/processor.py
+++ b/pydropsonde/processor.py
@@ -302,6 +302,7 @@ class Sonde:
         if hasattr(self, "postaspenfile"):
             try:
                 ds = xr.open_dataset(self.postaspenfile, engine="netcdf4")
+                ds = ds.assign(time=ds.time)
             except ValueError:
                 warnings.warn(f"No valid l1 file for {self}")
                 return None
@@ -733,7 +734,7 @@ class Sonde:
             "launch_time": (
                 str(self.aspen_ds.launch_time.values)
                 if hasattr(self.aspen_ds, "launch_time")
-                else np.datetime64(self.aspen_ds.base_time.values)
+                else np.datetime64(self.aspen_ds.base_time.values, "us")
             ),
             "is_floater": str(self.qc.is_floater),
             "sonde_serial_ID": self.serial_id,
@@ -1663,7 +1664,7 @@ class Sonde:
             dict(
                 launch_time=(
                     self.sonde_dim,
-                    [np.datetime64(self.launch_time, "ns")],
+                    [np.datetime64(self.launch_time, "us")],
                     essential_attrs["launch_time"],
                 )
             )

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -7,6 +7,11 @@ T = np.linspace(300, 200, 10)
 q = np.linspace(0.02, 0.002, 10)
 alt = np.linspace(0, 17000, 10)
 rh = np.repeat(0.8, 10)
+time = np.arange(
+    np.datetime64("2024-09-03T04:00:00.500"),
+    np.datetime64("2024-09-03T04:10:00.500"),
+    np.timedelta64(1, "m"),
+)
 
 ds = xr.Dataset(
     data_vars=dict(
@@ -14,13 +19,14 @@ ds = xr.Dataset(
         p=(["alt"], p, {"units": "Pa"}),
         rh=(["alt"], rh),
         q=(["alt"], q),
+        time=("alt", time),
     ),
     coords=dict(
         alt=("alt", alt),
     ),
     attrs={
         "example_attribute_(lines_of_code)": "23",
-        "launch_time_(UTC)": "20240903T04:00.000",
+        "launch_time_(UTC)": "2024-09-03T04:00:00.500",
     },
 )
 
@@ -42,3 +48,35 @@ def test_rh2q_range():
     assert rh2q.q.isel(alt=0).values > 0.01
     assert rh2q.q.isel(alt=0).values < 0.02
     assert rh2q.q.isel(alt=-1).values < 1e-4
+
+
+def test_time_encoding():
+    time_encoding = hh.xarray_helper.get_time_encoding(ds.time)
+    assert time_encoding["dtype"] == "int64"
+    assert "microseconds since" in time_encoding["units"]
+    assert np.datetime_as_string(time[0], "s") in time_encoding["units"]
+
+
+def test_time_encoding_nan():
+    time_encoding = hh.xarray_helper.get_time_encoding(
+        ds.time.where(ds.time < np.datetime64("2024-09-03T04:09:00"))
+    )
+    assert np.any(
+        np.isnan(ds.time.where(ds.time < np.datetime64("2024-09-03T04:09:00")))
+    )
+    assert time_encoding["dtype"] == "int64"
+    assert "microseconds since" in time_encoding["units"]
+    assert np.datetime_as_string(time[0], "s") in time_encoding["units"]
+    time_encoding = hh.xarray_helper.get_time_encoding(
+        ds.time.where(ds.time < np.datetime64("2024-09-03T03:09:00"))
+    )
+    assert np.all(
+        np.isnan(ds.time.where(ds.time < np.datetime64("2024-09-03T03:09:00")))
+    )
+    assert time_encoding["dtype"] == "int64"
+    assert "microseconds since" in time_encoding["units"]
+    assert np.datetime_as_string(time[0], "s") not in time_encoding["units"]
+    assert (
+        np.datetime_as_string(np.datetime64("1970-01-01T00:00:00"), "s")
+        in time_encoding["units"]
+    )


### PR DESCRIPTION
Hello, this is an answer to #209. I am very sorry for the delay. 

I decided to use the level 1 time encoding for Level 2 and the minimum of the Level 2 for the Level 3 and Level 4 encoding of the times (this usually leads to something like `seconds since ...` which hopefully should be fine. As a default, I use `microseconds since 2000-01-01`. 

Now, I am a bit unsure about some things: 
- would it more useful to have a "round time" after the since? For the example data it now is `'seconds since 2020-01-17T14:32:48'`, which is no problem technically, but it does not look so nice. 
- the `dtype` in Level 1 for times is `float64`. Does it make sense to change it to `float32`? 