### PR TITLE
rename aircraft_{latitude, longitude, msl_altitude} to launch_{lat, l…

### DIFF
--- a/pydropsonde/circles.py
+++ b/pydropsonde/circles.py
@@ -192,7 +192,7 @@ class Circle:
             dict(
                 circle_altitude=(
                     [],
-                    self.circle_ds["aircraft_msl_altitude"].mean().values,
+                    self.circle_ds["launch_altitude"].mean().values,
                     circle_altitude_attrs,
                 ),
                 circle_time=(

--- a/pydropsonde/helper/__init__.py
+++ b/pydropsonde/helper/__init__.py
@@ -104,25 +104,25 @@ l2_flight_attributes_map = {
     "Format Notes =": "AVAPS_format_notes",
     "True Heading (deg) =": "true_heading_(deg)",
     "Ground Track (deg) =": "ground_track_(deg)",
-    "Longitude (deg) =": "aircraft_longitude_(degrees_east)",
-    "Latitude (deg) =": "aircraft_latitude_(degrees_north)",
-    "MSL Altitude (m) =": "aircraft_msl_altitude_(m)",
-    "Geopotential Altitude (m) =": "aircraft_geopotential_altitude_(m)",
+    "Longitude (deg) =": "launch_lon_(degrees_east)",
+    "Latitude (deg) =": "launch_lat_(degrees_north)",
+    "MSL Altitude (m) =": "launch_altitude_(m)",
+    "Geopotential Altitude (m) =": "launch_geopotential_altitude_(m)",
 }
 
 l3_coords = dict(
     launch_time={"long_name": "dropsonde launch time", "time_zone": "UTC"},
-    aircraft_longitude={
+    launch_lon={
         "long_name": "aircraft longitude at launch",
         "units": "degrees_east",
         "source": "aircraft measurement",
     },
-    aircraft_latitude={
+    launch_lat={
         "long_name": "aircraft latitude at launch",
         "units": "degrees_north",
         "source": "aircraft measurement",
     },
-    aircraft_msl_altitude={
+    launch_altitude={
         "long_name": "aircraft altitude at launch",
         "units": "m",
         "source": "aircraft measurement",

--- a/pydropsonde/processor.py
+++ b/pydropsonde/processor.py
@@ -2006,9 +2006,9 @@ class Gridded:
         )
         concatenated_ds = concatenated_ds.reset_coords(
             [
-                "aircraft_latitude",
-                "aircraft_longitude",
-                "aircraft_msl_altitude",
+                "launch_lat",
+                "launch_lon",
+                "launch_altitude",
                 "sonde_id",
             ]
         )


### PR DESCRIPTION
this PR renames some variables to be more consistent with RAPSODI

- aircraft_latitude -> launch_lat
- aircraft_longitude -> launch_lon 
- aircraft_msl_altitude -> launch_altitude