### PR TITLE
Update l4 interpolation

### DIFF
--- a/pydropsonde/circles.py
+++ b/pydropsonde/circles.py
@@ -229,7 +229,14 @@ class Circle:
             {
                 var: (
                     ds[var].dims,
-                    ds[var].bfill(dim=self.alt_dim, limit=int(max_alt // 10)).values,
+                    ds[var]
+                    .interpolate_na(
+                        dim=self.alt_dim,
+                        method="nearest",
+                        max_gap=int(max_alt),
+                        fill_value="extrapolate",
+                    )
+                    .values,
                     ds[var].attrs,
                 )
                 for var in constant_vars

--- a/pydropsonde/circles.py
+++ b/pydropsonde/circles.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 import numpy as np
 import xarray as xr
 import circle_fit as cf
+import pydropsonde.helper as hh
 import pydropsonde.helper.physics as hp
 import pydropsonde.helper.xarray_helper as hx
 
@@ -297,6 +298,13 @@ class Circle:
             ds["p"] = np.exp(ds["p"])
             self.circle_ds = ds.swap_dims({"sonde_id": self.sonde_dim})
 
+        return self
+
+    def recalculate_ta_rh(self):
+        ds = self.circle_ds
+        ds = hh.calc_T_from_theta(ds)
+        ds = hh.calc_rh_from_q(ds)
+        self.circle_ds = ds
         return self
 
     def mask_sonde(self, sonde_id=0):

--- a/pydropsonde/circles.py
+++ b/pydropsonde/circles.py
@@ -93,6 +93,29 @@ class Circle:
         )
         return self
 
+    def interpolate_position(self, max_alt=300):
+        ds = self.circle_ds.sortby(self.alt_dim)
+
+        ds = ds.assign(
+            {
+                var: (
+                    ds[var].dims,
+                    ds[var]
+                    .interpolate_na(
+                        dim=self.alt_dim,
+                        method="nearest",
+                        max_gap=int(max_alt),
+                        fill_value="extrapolate",
+                    )
+                    .values,
+                    ds[var].attrs,
+                )
+                for var in ["lat", "lon"]
+            }
+        )
+        self.circle_ds = ds
+        return self
+
     def get_xy_coords_for_circles(self):
         """
         Calculate x and y from lat and lon relative to circle center.

--- a/pydropsonde/pipeline.py
+++ b/pydropsonde/pipeline.py
@@ -644,6 +644,7 @@ pipeline = {
         "intake": "gridded",
         "apply": iterate_Circle_method_over_dict_of_Circle_objects,
         "functions": [
+            "interpolate_position",
             "get_xy_coords_for_circles",
             "drop_vars",
             "interpolate_na_sondes",

--- a/pydropsonde/pipeline.py
+++ b/pydropsonde/pipeline.py
@@ -648,6 +648,7 @@ pipeline = {
             "drop_vars",
             "interpolate_na_sondes",
             "extrapolate_na_sondes",
+            "recalculate_ta_rh",
         ],
         "output": "gridded",
         "comment": "prepare circle dataset for calculation",


### PR DESCRIPTION
this pr updates the l4 interpolation of the sonde profiles.
 - it interpolates lat and Lon before the x & y positions are calculated (currently nearest neighbour, could be more elaborate at some point)
 - it changes bfill to nearest neighbour extrapolation at the surface, because bfill always fills values up to the length of the gap, which is not intended (this should not change much for the orcestra dataset)
 - ta and rh are calculated after the interpolation/extrapolation in L4, such that all variables are without gaps