### PR TITLE
Remove duplicate l2

### DIFF
--- a/pydropsonde/pipeline.py
+++ b/pydropsonde/pipeline.py
@@ -549,6 +549,7 @@ pipeline = {
             "add_sonde_id_variable",
             "add_platform_id_variable",
             "add_flight_id_variable",
+            "add_launch_time_variable",
             "add_qc_to_l2",
             "get_l2_filename",
             "update_history_l2",

--- a/pydropsonde/processor.py
+++ b/pydropsonde/processor.py
@@ -724,15 +724,7 @@ class Sonde:
             Returns the sonde with a new attribute "sonde_attrs"
         """
         sonde_attrs = {
-            "platform_id": self.platform_id,
-            "launch_time": (
-                str(self.aspen_ds.launch_time.values)
-                if hasattr(self.aspen_ds, "launch_time")
-                else np.datetime64(self.aspen_ds.base_time.values, "us")
-            ),
             "is_floater": str(self.qc.is_floater),
-            "sonde_serial_ID": self.serial_id,
-            "sonde_ID": self.id,
         }
         self.sonde_attrs = sonde_attrs
 

--- a/pydropsonde/processor.py
+++ b/pydropsonde/processor.py
@@ -808,6 +808,28 @@ class Sonde:
         self.interim_l2_ds = ds
         return self
 
+    def add_launch_time_variable(self):
+        if hasattr(self, "interim_l2_ds"):
+            ds = self.interim_l2_ds
+        else:
+            ds = self.aspen_ds
+
+        ds = ds.assign(
+            launch_time=(
+                np.datetime64(self.aspen_ds.launch_time.values, "us")
+                if hasattr(self.aspen_ds, "launch_time")
+                else np.datetime64(self.aspen_ds.base_time.values, "us")
+            )
+        )
+        ds["launch_time"] = ds["launch_time"].assign_attrs(
+            {
+                "long_name": "dropsonde launch time",
+                "time_zone": "UTC",
+            }
+        )
+        self.interim_l2_ds = ds
+        return self
+
     def add_flight_id_variable(self, variable_name="flight_id"):
         """
         Adds a variable and related attributes to the sonde object with the Sonde object (self)'s flight_id attribute.


### PR DESCRIPTION
This closes #225. 

It 
- adds launch_time as a variable to L2
- removes platform_id, sonde_id,  serial_id and launch_time from attributes, as they are also variables