### PR TITLE
Std names

### DIFF
--- a/pydropsonde/circles.py
+++ b/pydropsonde/circles.py
@@ -585,12 +585,10 @@ class Circle:
                         )
                     )
                     .broadcast_like(ds[div_error_name])
-                    .values
-                    * 0.01
-                    * 60**2,
+                    .values,
                     dict(
                         standard_name=f"{omega_std_name} standard_error",
-                        units=ds["omega"].attrs.get("units", "hPa hr-1"),
+                        units=ds["omega"].attrs.get("units", "Pa s-1"),
                     ),
                 )
             }
@@ -752,13 +750,13 @@ class Circle:
         if p.sizes["altitude"] > 0:
             pres_diff = xr.concat([zero_vel, p.diff(dim=alt_dim)], dim=alt_dim)
             del_omega = -div * pres_diff.values
-            omega = del_omega.cumsum(dim=alt_dim) * 0.01 * 60**2
+            omega = del_omega.cumsum(dim=alt_dim)
         else:
             omega = xr.DataArray(data=[np.nan], dims=alt_dim, coords={alt_dim: [0]})
         omega_attrs = {
             "standard_name": "vertical_air_velocity_expressed_as_tendency_of_pressure",
             "long_name": "Area-averaged atmospheric pressure velocity (omega)",
-            "units": "hPa hr-1",
+            "units": "Pa s-1",
         }
         self.circle_ds = ds.assign(
             dict(omega=(ds.div.dims, omega.broadcast_like(ds.div).values, omega_attrs))

--- a/pydropsonde/circles.py
+++ b/pydropsonde/circles.py
@@ -609,7 +609,13 @@ class Circle:
             errors="ignore",
         )
         if "iwv_mean" in self.circle_ds.variables:
-            self.circle_ds["iwv_mean"] = self.circle_ds["iwv_mean"].mean("altitude")
+            self.circle_ds = self.circle_ds.assign(
+                iwv_mean=(
+                    "circle",
+                    [self.circle_ds["iwv_mean"].mean("altitude").values],
+                    self.circle_ds["iwv_mean"].attrs,
+                )
+            )
         return self
 
     def calc_remove_sonde_manipulation(self):

--- a/pydropsonde/circles.py
+++ b/pydropsonde/circles.py
@@ -189,27 +189,27 @@ class Circle:
         Add circle metadata to the circle dataset.
         """
         circle_radius_attrs = {
-            "long_name": "circle_radius",
+            "long_name": "circle radius",
             "description": f"Radius of {self.method}",
             "units": "m",
         }
         circle_lon_attrs = {
-            "long_name": "circle_lon",
+            "long_name": "circle longitude",
             "description": f"Longitude of {self.method}",
             "units": "degrees_east",
         }
         circle_lat_attrs = {
-            "long_name": "circle_lat",
+            "long_name": "circle latitude",
             "description": f"Latitude of {self.method}",
             "units": "degrees_north",
         }
         circle_altitude_attrs = {
-            "long_name": "circle_altitude",
+            "long_name": "circle altitude",
             "description": "Mean altitude of the aircraft during the circle",
             "units": self.circle_ds[self.alt_dim].attrs["units"],
         }
         circle_time_attrs = {
-            "long_name": "circle_time",
+            "long_name": "circle time",
             "time_zone": "UTC",
             "description": "Mean launch time of first and last sonde in circle",
         }

--- a/pydropsonde/circles.py
+++ b/pydropsonde/circles.py
@@ -532,7 +532,7 @@ class Circle:
             }
         )
         vor_std_name = ds["vor"].attrs.get(
-            "standard_name", "atmosphere_relative_vorticity"
+            "standard_name", "atmosphere_upward_relative_vorticity"
         )
         ds = ds.assign(
             {
@@ -726,8 +726,8 @@ class Circle:
         ds = self.circle_ds
         vor = ds.v_dvdx - ds.u_dudy
         vor_attrs = {
-            "standard_name": "atmosphere_relative_vorticity",
-            "long_name": "Area-averaged horizontal relative vorticity",
+            "standard_name": "atmosphere_upward_relative_vorticity",
+            "long_name": "Area-averaged relative vorticity",
             "units": "s-1",
         }
         self.circle_ds = ds.assign(vor=(ds.u_dudx.dims, vor.values, vor_attrs))

--- a/pydropsonde/circles.py
+++ b/pydropsonde/circles.py
@@ -417,9 +417,9 @@ class Circle:
                     "meridional gradient of " + long_name,
                 ]
                 use_names = [
-                    standard_name + "_circle_mean",
-                    "derivative_of_" + standard_name + "_wrt_x",
-                    "derivative_of_" + standard_name + "_wrt_y",
+                    "",
+                    "eastward_derivative_of_" + standard_name,
+                    "northward_derivative_of_" + standard_name,
                 ]
                 try:
                     weight = self.circle_ds[f"{par}_weights"]
@@ -491,13 +491,9 @@ class Circle:
             se_x = np.sqrt(nominator / dx_denominator)
             se_y = np.sqrt(nominator / dy_denominator)
 
-            dvardx_std_name = ds[dvardx_name].attrs.get(
-                "standard_name", f"derivative_of_{var}_wrt_x"
-            )
+            dvardx_std_name = ds[dvardx_name].attrs.get("standard_name", "")
             unit = ds[dvardx_name].attrs.get("units", "")
-            dvardy_std_name = ds[dvardy_name].attrs.get(
-                "standard_name", f"derivative_of_{var}_wrt_y"
-            )
+            dvardy_std_name = ds[dvardy_name].attrs.get("standard_name", "")
 
             ds = ds.assign(
                 {

--- a/pydropsonde/helper/__init__.py
+++ b/pydropsonde/helper/__init__.py
@@ -242,7 +242,7 @@ def calc_q_from_rh_sonde(ds):
         q_attrs = dict(
             standard_name="specific_humidity",
             long_name="specific humidity",
-            units="1",
+            units="kg kg-1",
             method="calculated from measured RH following Hardy 1998",
         )
     ds = ds.assign(
@@ -280,7 +280,7 @@ def calc_q_from_rh(ds):
         q_attrs = dict(
             standard_name="specific_humidity",
             long_name="specific humidity",
-            units="1",
+            units="kg kg-1",
             method=f"calculated from RH following {es_name}",
         )
     ds = ds.assign(

--- a/pydropsonde/helper/__init__.py
+++ b/pydropsonde/helper/__init__.py
@@ -45,7 +45,7 @@ l2_variables = {
         "attributes": {
             "standard_name": "relative_humidity",
             "long_name": "relative humidity",
-            "units": "",
+            "units": "1",
         },
     },
     "lat": {

--- a/pydropsonde/helper/__init__.py
+++ b/pydropsonde/helper/__init__.py
@@ -114,11 +114,13 @@ l3_coords = dict(
     launch_time={"long_name": "dropsonde launch time", "time_zone": "UTC"},
     launch_lon={
         "long_name": "aircraft longitude at launch",
+        "standard_name": "deployment_longitude",
         "units": "degrees_east",
         "source": "aircraft measurement",
     },
     launch_lat={
         "long_name": "aircraft latitude at launch",
+        "standard_name": "deployment_latitude",
         "units": "degrees_north",
         "source": "aircraft measurement",
     },

--- a/pydropsonde/helper/__init__.py
+++ b/pydropsonde/helper/__init__.py
@@ -420,7 +420,7 @@ def calc_theta_from_T(ds):
         theta_attrs = dict(
             standard_name="air_potential_temperature",
             long_name="dry potential temperature",
-            units="kelvin",
+            units="K",
         )
     theta_attrs.update(dict(method="calculated from measured ta and p"))
     ds = ds.assign(theta=(ds.ta.dims, theta, theta_attrs))
@@ -481,7 +481,7 @@ def calc_theta_e(ds):
             dict(
                 standard_name="air_equivalent_potential_temperature",
                 long_name="equivalent potential temperature",
-                units="kelvin",
+                units="K",
             ),
         )
     )

--- a/pydropsonde/helper/__init__.py
+++ b/pydropsonde/helper/__init__.py
@@ -72,6 +72,7 @@ l2_variables = {
             "standard_name": "time",
             "long_name": "time of recorded measurement",
             "axis": "T",
+            "time_zone": "UTC",
         },
     },
     "gpsalt": {

--- a/pydropsonde/helper/quality.py
+++ b/pydropsonde/helper/quality.py
@@ -449,7 +449,9 @@ class QualityControl:
         get the correct unit for the detailed qc value. Depends on the last bit of the qc detail name
         """
         var_unit = self.qc_vars[var_name]
-        if (
+        if (qc_name.endswith("extent_max")) or (qc_name.endswith("extent_min")):
+            return "m"
+        elif (
             (qc_name.endswith("diff"))
             or (qc_name.endswith("min"))
             or (qc_name.endswith("max"))

--- a/pydropsonde/helper/quality.py
+++ b/pydropsonde/helper/quality.py
@@ -436,7 +436,7 @@ class QualityControl:
             qc_status = "UGLY"
         attrs = dict(
             long_name=f"qc for {variable}",
-            standard_name="status_flag",
+            standard_name="quality_flag",
             flag_masks=", ".join([f"{2**x}b" for x in range(i + 1)]),
             flag_meanings=", ".join(keys),
             description="if non-zero, this sonde should be used with care.",

--- a/pydropsonde/processor.py
+++ b/pydropsonde/processor.py
@@ -1585,7 +1585,7 @@ class Sonde:
             m_name = f"{variable}_m_qc"
             m_attrs = {
                 "long_name": f"interp method for {variable}",
-                "standard_name": "status_flag",
+                "standard_name": "quality_flag",
                 "flag_values": "0, 1, 2",
                 "flag_meanings": "no_data interpolated_no_raw_data average_over_raw_data",
             }


### PR DESCRIPTION
I hope this makes the dataset a bit cleaner. 
it 
- uses the same notation for the unit K in theta as in T
- changes the unit for q to kg/kg
- fixes the standard names of the derivatives and vorticity (I hope)
- removes the standard name for circle means, as there seems to be none suitable
- adds standard name "deployment_*" for launch lat and Lon.